### PR TITLE
Update Wait-RSJob and Receive-RSJob to support pipeline streaming

### DIFF
--- a/PoshRSJob/Scripts/Receive-RSJob.ps1
+++ b/PoshRSJob/Scripts/Receive-RSJob.ps1
@@ -76,7 +76,10 @@ Function Receive-RSJob {
         }
     }
     Process {
-        If (-Not $Bound) {
+        If (-Not $Bound -and $Job) {
+            $_.Output
+        }
+        elseif (-Not $Bound) {
             [void]$List.Add($_)
         }
     }
@@ -102,10 +105,6 @@ Function Receive-RSJob {
         }
         If ($ScriptBlock) {
             $jobs | Where $ScriptBlock | Select -ExpandProperty Output
-        } Else {
-            ForEach ($Item in $list) {
-                $Item.Output
-            }
         }
     }
 }

--- a/PoshRSJob/Scripts/Wait-RSJob.ps1
+++ b/PoshRSJob/Scripts/Wait-RSJob.ps1
@@ -137,7 +137,7 @@ Function Wait-RSJob {
                 })
               
                 #reuse $JustFinishedJobs to determine $WaitJobs in case a job state has changed between then and now for consistency
-                #Update $WaitJobs so the next loop cana determine the differences between this loop and the next for the $JustFinishedJobs to output
+                #Update $WaitJobs so the next loop can determine the differences between this loop and the next for the $JustFinishedJobs to output
                 $Waitjobs = $Waitjobs | Where { $_.ID -notin $JustFinishedJobs.ID }
 
                 #Wait just a bit so the HasMoreData can update if needed

--- a/PoshRSJob/Scripts/Wait-RSJob.ps1
+++ b/PoshRSJob/Scripts/Wait-RSJob.ps1
@@ -129,13 +129,15 @@ Function Wait-RSJob {
             $WaitJobs = $FilteredJobs
             $TotalJobs = $FilteredJobs.Count
             Write-Verbose "$($FilteredJobs.Count)"
-			$Date = Get-Date
-			Do{
-                
-				$JustFinishedJobs = @($Waitjobs | Where {
-                    $_.State -match 'Completed|Failed|Stopped|Suspended|Disconnected'
+            $Date = Get-Date
+            Do{               
+            	$JustFinishedJobs = @($Waitjobs | Where {
+            	    #Since the jobs' state can change independent of this cmdlet we only check it once per loop for consistency
+            	    $_.State -match 'Completed|Failed|Stopped|Suspended|Disconnected'
                 })
               
+                #reuse $JustFinishedJobs to determine $WaitJobs in case a job state has changed between then and now for consistency
+                #Update $WaitJobs so the next loop cana determine the differences between this loop and the next for the $JustFinishedJobs to output
                 $Waitjobs = $Waitjobs | Where { $_.ID -notin $JustFinishedJobs.ID }
 
                 #Wait just a bit so the HasMoreData can update if needed
@@ -143,20 +145,20 @@ Function Wait-RSJob {
                 $JustFinishedJobs
 
                 $Completed += $JustFinishedJobs.Count
-				Write-Verbose "Wait: $($Waitjobs.Count)"
+		Write-Verbose "Wait: $($Waitjobs.Count)"
                 Write-Verbose "Completed: ($Completed)"
                 Write-Verbose "Total: ($Totaljobs)"
                 Write-Verbose "Status: $($Completed/$TotalJobs)"
                 If ($PSBoundParameters.ContainsKey('ShowProgress')) {
                     Write-Progress -Activity "RSJobs Tracker" -Status ("Remaining Jobs: {0}" -f $Waitjobs.Count) -PercentComplete (($Completed/$TotalJobs)*100)
                 }
-				if($Timeout){
-					if((New-Timespan $Date).TotalSeconds -ge $Timeout){
-						$TimedOut = $True
-                        break
-					}
-				}		
-			} 
+		if($Timeout){
+		    if((New-Timespan $Date).TotalSeconds -ge $Timeout){
+		        $TimedOut = $True
+		        break
+		    }
+		}		
+	    } 
             While($Waitjobs.Count -ne 0)
         }
     }

--- a/PoshRSJob/Scripts/Wait-RSJob.ps1
+++ b/PoshRSJob/Scripts/Wait-RSJob.ps1
@@ -1,4 +1,4 @@
-﻿Function Wait-RSJob {
+Function Wait-RSJob {
     <#
         .SYNOPSIS
             Waits until all RSJobs are in one of the following states: 
@@ -126,34 +126,38 @@
             Write-Verbose "WhereString: $($WhereString)" 
             Write-Verbose "Using scriptblock"
             $FilteredJobs = @($list | Where $ScriptBlock)
+            $WaitJobs = $FilteredJobs
             $TotalJobs = $FilteredJobs.Count
             Write-Verbose "$($FilteredJobs.Count)"
 			$Date = Get-Date
 			Do{
-				$Waitjobs = @($FilteredJobs | Where {
-                    $_.State -notmatch 'Completed|Failed|Stopped|Suspended|Disconnected'
+                
+				$JustFinishedJobs = @($Waitjobs | Where {
+                    $_.State -match 'Completed|Failed|Stopped|Suspended|Disconnected'
                 })
-                $Completed = $TotalJobs - $Waitjobs.count
+              
+                $Waitjobs = $Waitjobs | Where { $_.ID -notin $JustFinishedJobs.ID }
+
+                #Wait just a bit so the HasMoreData can update if needed
+                Start-Sleep -Milliseconds 100
+                $JustFinishedJobs
+
+                $Completed += $JustFinishedJobs.Count
 				Write-Verbose "Wait: $($Waitjobs.Count)"
                 Write-Verbose "Completed: ($Completed)"
                 Write-Verbose "Total: ($Totaljobs)"
-                Write-Verbose "Status: $($Completed.count/$TotalJobs)"
+                Write-Verbose "Status: $($Completed/$TotalJobs)"
                 If ($PSBoundParameters.ContainsKey('ShowProgress')) {
-                    Write-Progress -Activity "RSJobs Tracker" -Status ("Remaining Jobs: {0}" -f $Waitjobs.count) -PercentComplete (($Completed/$TotalJobs)*100)
+                    Write-Progress -Activity "RSJobs Tracker" -Status ("Remaining Jobs: {0}" -f $Waitjobs.Count) -PercentComplete (($Completed/$TotalJobs)*100)
                 }
 				if($Timeout){
 					if((New-Timespan $Date).TotalSeconds -ge $Timeout){
 						$TimedOut = $True
                         break
 					}
-				}
-				Start-Sleep -Milliseconds 100
-			}While($Waitjobs.Count -ne 0)
-        }
-        If (-NOT $TimedOut) {
-            #Wait just a bit so the HasMoreData can update if needed
-            Start-Sleep -Milliseconds 100
-            $FilteredJobs
+				}		
+			} 
+            While($Waitjobs.Count -ne 0)
         }
     }
 }


### PR DESCRIPTION
Here are the edits to allow both these cmdlets to stream job objects and output more effectively.
Wait-RSJob now finds the jobs that have just finished that loop, removes them from the collection of jobs it's still waiting for, then outputs them. I updated the progress logic and looping control to reflect this small structure change.

Receive-RSJob was rather easy to update. All it needed was an extra condition to check for an incoming job on the pipeline in the process block, then output it if true. Should retain all original functionality.

I tested these enough to make sure they work the way I intended, but I didn't test extensively. So I'd suggest testing it a bit more during your review.