### PR TITLE
Add streaming output functionality to Receive-RSJob

### DIFF
--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -76,7 +76,10 @@ Function Receive-RSJob {
         }
     }
     Process {
-        If (-Not $Bound) {
+        If (-Not $Bound -and $Job) {
+            $_.Output
+        }
+        elseif (-Not $Bound) {
             [void]$List.Add($_)
         }
     }
@@ -102,10 +105,6 @@ Function Receive-RSJob {
         }
         If ($ScriptBlock) {
             $jobs | Where $ScriptBlock | Select -ExpandProperty Output
-        } Else {
-            ForEach ($Item in $list) {
-                $Item.Output
-            }
         }
     }
 }


### PR DESCRIPTION
Catches the case where Receive-RSJob is piped jobs with no parameters to filter on. This is done in the process block, allowing the jobs to be output to be streamed during the process block, rather than as a collection during the end block.