### PR TITLE
Add Verbose, Error and Warning stream output to Receive-RSJob

### DIFF
--- a/PoshRSJob/Private/WriteStream.ps1
+++ b/PoshRSJob/Private/WriteStream.ps1
@@ -1,0 +1,21 @@
+﻿Function WriteStream {
+    [CmdletBinding()]
+    Param (
+        [Parameter(ValueFromPipeline=$true)]
+        [Object]$IndividualJob
+    )
+
+    Process {
+        #First write the verbose stream...
+        Write-Verbose $IndividualJob.Verbose
+
+        #Write the warning stream...
+        Write-Warning $IndividualJob.Warning
+
+        #Write the error stream...
+        Write-Error $IndividualJob.Error
+
+        #Write StdOut
+        Write-Output $IndividualJob.Output
+    }
+}

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -57,27 +57,6 @@ Function Receive-RSJob {
         [PoshRS.PowerShell.RSJob[]]$Job
     )
     Begin {
-        Function Write-Stream {
-            Param (
-                [PoshRS.PowerShell.RSJob]$IndividualJob
-            )
-
-            #First write the verbose stream...
-            ForEach ($Item in $IndividualJob.Verbose)
-            {
-                Write-Verbose $Item
-            }
-
-            #Write the error stream...
-            ForEach ($Item in $IndividualJob.Error)
-            {
-                Write-Error $Item
-            }
-
-            #Write StdOut
-            Write-Output $IndividualJob.Output
-        }
-
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
         }        
@@ -108,7 +87,7 @@ Function Receive-RSJob {
     }
     Process {
         If (-Not $Bound -and $Job) {
-            Write-Stream -IndividualJob $_.Output
+            WriteStream -IndividualJob $_.Output
         }
         elseif (-Not $Bound) {
             [void]$List.Add($_)
@@ -140,10 +119,7 @@ Function Receive-RSJob {
             Default {$ScriptBlock=$Null}
         }
         If ($ScriptBlock) {
-            ForEach ($IJ in ($jobs | Where $ScriptBlock))
-            {
-                Write-Stream -IndividualJob $IJ
-            }
+            $jobs | Where $ScriptBlock | WriteStream
         }
     }
 }


### PR DESCRIPTION
Add Verbose, Error and Warning stream output to Receive-RSJob

1. Added pipeline support
2. Added warning stream support
3. Separated function to Private and following naming convention
4. Simplified output code