### PR TITLE
Update Start-RSJob.ps1

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -209,7 +209,9 @@ Function Start-RSJob {
             [void]$InitialSessionState.ImportPSModule($ModulesToImport)
         }
         If ($PSBoundParameters['PSSnapinsToImport']) {
-            [void]$InitialSessionState.ImportPSSnapIn($PSSnapinsToImport,[ref]$Null)
+            ForEach ($PSSnapin in $PSSnapinsToImport) {
+                [void]$InitialSessionState.ImportPSSnapIn($PSSnapin,[ref]$Null)
+            }
         }
         If ($PSBoundParameters['FunctionsToLoad']) {
             Write-Verbose "Loading custom functions: $($FunctionsToLoad -join '; ')"


### PR DESCRIPTION
ImportPSSnapIn only supports [string] and not [string[]]
https://msdn.microsoft.com/en-us/library/system.management.automation.runspaces.initialsessionstate.importpssnapin(v=vs.85).aspx