### PR TITLE
Compromise between issues #75 and #108

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -165,7 +165,7 @@ Function Start-RSJob {
         [parameter()]
         [object]$Name,
         [parameter()]
-        [string]$Batch,
+        [string]$Batch = $([guid]::NewGuid().ToString()),
         [parameter()]
         $ArgumentList,
         [parameter()]
@@ -394,8 +394,9 @@ Function Start-RSJob {
         Write-Debug "ScriptBlock: $($NewScriptBlock)"
 
         #region RunspacePool Creation        
+        <#
         If (-NOT $PSBoundParameters.ContainsKey('Batch')) {
-            <#
+            
             If ($PoshRS_RunspacePools.Count -gt 0) {
                 [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) 
                 $RSPObject = $PoshRS_RunspacePools[0]
@@ -406,7 +407,7 @@ Function Start-RSJob {
                 [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)
             }
             Else {
-            #>
+            
                 $Batch = $RunspacePoolID = [guid]::NewGuid().ToString()
                 Write-Verbose "Creating new runspacepool <$Batch>"
                 $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
@@ -431,7 +432,8 @@ Function Start-RSJob {
             #}
         }
         Else {    
-        <#        
+        #>
+                
             [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) 
             $__RSPObject = $PoshRS_RunspacePools | Where {
                 $_.RunspacePoolID -eq $Batch
@@ -442,7 +444,6 @@ Function Start-RSJob {
                 $RSPObject.LastActivity = $RSPObject.LastActivity.AddMinutes(5)
             }
             Else {
-            #>
                 Write-Verbose "Creating new runspacepool <$Batch>"
                 $RunspacePoolID = $Batch
                 $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
@@ -464,9 +465,9 @@ Function Start-RSJob {
                 
                 [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
                 [void]$PoshRS_RunspacePools.Add($RSPObject)
-            #}
+            }
             [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)            
-        }
+        <#}#>
         #endregion RunspacePool Creation
 
         If ($List.Count -gt 0) {

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -463,7 +463,7 @@ Function Start-RSJob {
                     RunspacePoolID = $RunspacePoolID
                 }
                 
-                [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
+                #[System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
                 [void]$PoshRS_RunspacePools.Add($RSPObject)
             }
             [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)            


### PR DESCRIPTION
Try to reconcile issues https://github.com/proxb/PoshRSJob/issues/75 and https://github.com/proxb/PoshRSJob/issues/108

Should note that invoke `Start-RSJob` with `-Batch` parameter use the same runspace and thus environment(functions/modules/etc) filled only on the first run...
but if second run will be long after first completed, then new environment _can_ be generated because runspace clean can happen in between runs.

Ergo...  user must be notified: when use several calls to `Start-RSJob` with same `-Batch` name - the calls must use the same environment `-XXX-toImport` parameters or result will be **unpredictable**
