### PR TITLE
#124 fix powershell_ise processes

### DIFF
--- a/PoshRSJob/PoshRSJob.psd1
+++ b/PoshRSJob/PoshRSJob.psd1
@@ -14,7 +14,7 @@
 ModuleToProcess = 'PoshRSJob.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7.3.5'
+ModuleVersion = '1.7.3.6'
 
 # ID used to uniquely identify this module
 GUID = '9b17fb0f-e939-4a5c-b194-3f2247452972'

--- a/PoshRSJob/PoshRSJob.psm1
+++ b/PoshRSJob/PoshRSJob.psm1
@@ -283,7 +283,7 @@ New-Alias -Name wsj -Value Wait-RSJob -Force
 #endregion Aliases
 
 #region Handle Module Removal
-$ExecutionContext.SessionState.Module.OnRemove ={
+$PoshRS_OnRemoveScript = {
     $PoshRS_jobCleanup.Flag=$False
     $PoshRS_RunspacePoolCleanup.Flag=$False
     #Let sit for a second to make sure it has had time to stop
@@ -298,6 +298,8 @@ $ExecutionContext.SessionState.Module.OnRemove ={
     Remove-Variable PoshRS_RunspacePoolCleanup -Scope Global -Force
     Remove-Variable PoshRS_RunspacePools -Scope Global -Force
 }
+$ExecutionContext.SessionState.Module.OnRemove += $PoshRS_OnRemoveScript
+Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PsEngineEvent]::Exiting) -Action $PoshRS_OnRemoveScript
 #endregion Handle Module Removal
 
 #region Export Module Members

--- a/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
+++ b/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
@@ -4,35 +4,47 @@
         [parameter()]
         [string[]]$Name
     )    
+    $FoundName = @()
     Write-Verbose "Getting callstacks"
     $PSCallStack = Get-PSCallStack
     Write-Verbose "PSCallStacks: `n$($PSCallStack|Out-String)"
     If ($PSCallStack.count -gt 1) {
-        #Ensure that I always get the second item in the call stack
-        $CallStack = $PSCallStack | Select-Object -First 1 -Skip 2
-        Switch ($PSVersionTable.PSVersion.Major) {
-            '2' {
-                $ScriptBlock = Get-Content $CallStack.ScriptName
-                $Functions = @(FindFunction -ScriptBlock ($ScriptBlock | Out-String))
-            }
-            Default {
-                $Flags = [System.Reflection.BindingFlags]'nonpublic,instance,static'
-                $FunctionContext = $CallStack.GetType().GetProperty('FunctionContext',$Flags).GetValue($CallStack,$Null)
-                $ScriptBlock = $FunctionContext.GetType().GetField('_scriptBlock',$Flags).GetValue($FunctionContext)
-                $Functions = @(($ScriptBlock.ast.FindAll({$args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst]},$False)))
-            }
-        }
-        Write-Verbose ("Found {0} functions" -f $Functions.count)
-        Write-Verbose "Functions found: `n$($Functions | Select -Expand Name|Out-String)"
-        $Functions | ForEach {
-            If ($PSBoundParameters.ContainsKey('Name')) {
-                If ($Name -contains $_.Name ) {
-                    Write-Verbose "Loading $($_.Name)" 
-                    .([scriptblock]::Create("Function Script:$($_.Name) $($_.Body)"))
+        foreach ($CallStack in ($PSCallStack | Select-Object -Skip 2)) {
+            Switch ($PSVersionTable.PSVersion.Major) {
+                '2' {
+                    $ScriptBlock = Get-Content $CallStack.ScriptName
+                    $Functions = @(FindFunction -ScriptBlock ($ScriptBlock | Out-String))
                 }
-            } Else {
-                Write-Verbose "Loading $($_.Name)" 
-                .([scriptblock]::Create("Function Script:$($_.Name) $($_.Body)"))
+                Default {
+                    $Flags = [System.Reflection.BindingFlags]'nonpublic,instance,static'
+                    $FunctionContext = $CallStack.GetType().GetProperty('FunctionContext',$Flags).GetValue($CallStack,$Null)
+                    $ScriptBlock = $FunctionContext.GetType().GetField('_scriptBlock',$Flags).GetValue($FunctionContext)
+                    $Functions = @(($ScriptBlock.ast.FindAll({$args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst]},$False)))
+                }
+            }
+            Write-Verbose ("Found {0} functions" -f $Functions.count)
+            Write-Verbose "Functions found in callstack $Callstack`n$($Functions | Select-Object -Expand Name|Out-String)"
+            if ($Functions) {
+                $Functions | ForEach-Object {
+                    If ($PSBoundParameters.ContainsKey('Name')) {
+                        If ($Name -contains $_.Name -and $FoundName -notcontains $_.Name) {
+                            Write-Verbose "Loading $($_.Name)" 
+                            $FoundName += $_.Name
+                            .([scriptblock]::Create("Function Script:$($_.Name) $($_.Body)"))
+                        }
+                    } Else {
+                        if ($FoundName -notcontains $_.Name) {
+                            Write-Verbose "Loading $($_.Name)" 
+                            $FoundName += $_.Name
+                            .([scriptblock]::Create("Function Script:$($_.Name) $($_.Body)"))
+                        }
+                    }
+                }
+
+                # Stop searching callstacks once we found what we want   
+                if ($Name.Count -eq $FoundName.Count) {       
+                    break
+                }
             }
         }
     }

--- a/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
+++ b/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
@@ -9,7 +9,7 @@
     Write-Verbose "PSCallStacks: `n$($PSCallStack|Out-String)"
     If ($PSCallStack.count -gt 1) {
         #Ensure that I always get the second item in the call stack
-        $CallStack = $PSCallStack[-2]
+        $CallStack = $PSCallStack | Select-Object -First 1 -Skip 2
         Switch ($PSVersionTable.PSVersion.Major) {
             '2' {
                 $ScriptBlock = Get-Content $CallStack.ScriptName


### PR DESCRIPTION
OnRemove doesn't appear to trigger with PowerShell ISE exits. However
PsEngineEvent does trigger. This appears to fix the problem and cause
ISE to close after the second Dispose in the script block.