### PR TITLE
Unified Get-RSJob, Receive-RSJob, Remove-RSJob, Stop-RSJob, Wait-RSJob interface (#141)

### DIFF
--- a/PoshRSJob/PoshRSJob.psm1
+++ b/PoshRSJob/PoshRSJob.psm1
@@ -1,5 +1,5 @@
 $ScriptPath = Split-Path $MyInvocation.MyCommand.Path
-$PSModule = $ExecutionContext.SessionState.Module 
+$PSModule = $ExecutionContext.SessionState.Module
 $PSModuleRoot = $PSModule.ModuleBase
 If ($PSVersionTable['PSEdition'] -and $PSVersionTable.PSEdition -eq 'Core') {
 #PowerShell V4 and below will throw a parser error even if I never use the classes keyword
@@ -10,7 +10,7 @@ If ($PSVersionTable['PSEdition'] -and $PSVersionTable.PSEdition -eq 'Core') {
         [object]$Value
         [string]$NewVarName
     }
- 
+
     class RSRunspacePool{
         [System.Management.Automation.Runspaces.RunspacePool]$RunspacePool
         [System.Management.Automation.Runspaces.RunspacePoolState]$State
@@ -53,7 +53,7 @@ Else {
     using System.Collections.Generic;
     using System.Text;
     using System.Management.Automation;
- 
+
     public class V2UsingVariable
     {
         public string Name;
@@ -61,7 +61,7 @@ Else {
         public object Value;
         public string NewVarName;
     }
- 
+
     public class RSRunspacePool
     {
         public System.Management.Automation.Runspaces.RunspacePool RunspacePool;
@@ -115,60 +115,64 @@ New-Variable PoshRS_RunspacePoolCleanup -Value ([hashtable]::Synchronized(@{})) 
 Write-Verbose "Creating routine to monitor RS jobs"
 $PoshRS_jobCleanup.Flag=$True
 $PoshRS_jobCleanup.Host = $Host
-$PoshRS_jobCleanup.Runspace =[runspacefactory]::CreateRunspace()   
-$PoshRS_jobCleanup.Runspace.Open()         
-$PoshRS_jobCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_jobCleanup",$PoshRS_jobCleanup)     
-$PoshRS_jobCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_Jobs",$PoshRS_Jobs) 
+$PoshRS_jobCleanup.Runspace =[runspacefactory]::CreateRunspace()
+$PoshRS_jobCleanup.Runspace.Open()
+$PoshRS_jobCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_jobCleanup",$PoshRS_jobCleanup)
+$PoshRS_jobCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_Jobs",$PoshRS_Jobs)
 $PoshRS_jobCleanup.PowerShell = [PowerShell]::Create().AddScript({
     #Routine to handle completed runspaces
-    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("Begin Do Loop") 
-    Do {   
-        [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot) 
-        Foreach($job in $PoshRS_Jobs) {            
-            If ($job.Handle.isCompleted -AND (-NOT $Job.Completed)) {   
-                #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) completed")  
-                $Data = $null
-                Try {           
-                    $Data = $job.InnerJob.EndInvoke($job.Handle)
-                } Catch {
-                    $CaughtErrors = $Error
-                    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Caught terminating Error in job: $_") 
-                }
-                #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Checking for errors") 
-                If ($job.InnerJob.Streams.Error -OR $CaughtErrors) {
-                    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Errors Found!")
-                    $ErrorList = New-Object System.Management.Automation.PSDataCollection[System.Management.Automation.ErrorRecord]
-                    If ($job.InnerJob.Streams.Error) {
-                        ForEach ($Err in $job.InnerJob.Streams.Error) {
-                            #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("`t$($Job.Id) Adding Error")             
-                            [void]$ErrorList.Add($Err)
+    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("Begin Do Loop")
+    Do {
+        [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot)
+        try {
+            Foreach($job in $PoshRS_Jobs) {
+                If ($job.Handle.isCompleted -AND (-NOT $Job.Completed)) {
+                    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) completed")
+                    $Data = $null
+                    Try {
+                        $Data = $job.InnerJob.EndInvoke($job.Handle)
+                    } Catch {
+                        $CaughtErrors = $Error
+                        #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Caught terminating Error in job: $_")
+                    }
+                    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Checking for errors")
+                    If ($job.InnerJob.Streams.Error -OR $CaughtErrors) {
+                        #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Errors Found!")
+                        $ErrorList = New-Object System.Management.Automation.PSDataCollection[System.Management.Automation.ErrorRecord]
+                        If ($job.InnerJob.Streams.Error) {
+                            ForEach ($Err in $job.InnerJob.Streams.Error) {
+                                #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("`t$($Job.Id) Adding Error")
+                                [void]$ErrorList.Add($Err)
+                            }
                         }
+                        If ($CaughtErrors) {
+                            ForEach ($Err in $CaughtErrors) {
+                                #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("`t$($Job.Id) Adding Error")
+                                [void]$ErrorList.Add($Err)
+                            }
+                        }
+                        $job.Error = $ErrorList
                     }
-                    If ($CaughtErrors) {
-                        ForEach ($Err in $CaughtErrors) {
-                            #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("`t$($Job.Id) Adding Error")             
-                            [void]$ErrorList.Add($Err)
-                        }                    
+                    #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Disposing job")
+                    $job.InnerJob.dispose()
+                    #Return type from Invoke() is a generic collection; need to verify the first index is not NULL
+                    If (($Data.Count -gt 0) -AND (-NOT ($Data.Count -eq 1 -AND $Null -eq $Data[0]))) {
+                        $job.output = $Data
+                        $job.HasMoreData = $True
                     }
-                    $job.Error = $ErrorList
+                    $Error.Clear()
+                    $job.Completed = $True
                 }
-                #$PoshRS_jobCleanup.Host.UI.WriteVerboseLine("$($Job.Id) Disposing job")
-                $job.InnerJob.dispose() 
-                #Return type from Invoke() is a generic collection; need to verify the first index is not NULL
-                If (($Data.Count -gt 0) -AND (-NOT ($Data.Count -eq 1 -AND $Null -eq $Data[0]))) {   
-                    $job.output = $Data
-                    $job.HasMoreData = $True                           
-                }              
-                $Error.Clear()
-                $job.Completed = $True
-            } 
-        }        
-        [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot)
-        Start-Sleep -Milliseconds 100     
+            }
+        }
+        finally {
+            [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot)
+        }
+        Start-Sleep -Milliseconds 100
     } while ($PoshRS_jobCleanup.Flag)
 })
 $PoshRS_jobCleanup.PowerShell.Runspace = $PoshRS_jobCleanup.Runspace
-$PoshRS_jobCleanup.Handle = $PoshRS_jobCleanup.PowerShell.BeginInvoke()  
+$PoshRS_jobCleanup.Handle = $PoshRS_jobCleanup.PowerShell.BeginInvoke()
 
 Write-Verbose "Creating routine to monitor Runspace Pools"
 $PoshRS_RunspacePoolCleanup.Flag=$True
@@ -176,7 +180,7 @@ $PoshRS_RunspacePoolCleanup.Host=$Host
 #2 minute timeout for unused runspace pools
 $PoshRS_RunspacePoolCleanup.Timeout = [timespan]::FromMinutes(2).Ticks
 $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
- 
+
 #Create Type Collection so the object will work properly
 $Types = Get-ChildItem "$($PSScriptRoot)\TypeData" -Filter *Types* | Select-Object -ExpandProperty Fullname
 ForEach ($Type in $Types) {
@@ -184,62 +188,66 @@ ForEach ($Type in $Types) {
     $InitialSessionState.Types.Add($TypeConfigEntry)
 }
 $PoshRS_RunspacePoolCleanup.Runspace =[runspacefactory]::CreateRunspace($InitialSessionState)
-  
-$PoshRS_RunspacePoolCleanup.Runspace.Open()         
-$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_RunspacePoolCleanup",$PoshRS_RunspacePoolCleanup)     
-$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_RunspacePools",$PoshRS_RunspacePools) 
-$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("ParentHost",$Host) 
+
+$PoshRS_RunspacePoolCleanup.Runspace.Open()
+$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_RunspacePoolCleanup",$PoshRS_RunspacePoolCleanup)
+$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_RunspacePools",$PoshRS_RunspacePools)
+$PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("ParentHost",$Host)
 $PoshRS_RunspacePoolCleanup.PowerShell = [PowerShell]::Create().AddScript({
     #Routine to handle completed runspaces
     $DisposePoshRS_RunspacePools=$False
-    Do { 
+    Do {
         #$ParentHost.ui.WriteVerboseLine("Beginning Do Statement")
         If ($DisposePoshRS_RunspacePools) {
             #Perform garbage collection
             [gc]::Collect()
         }
         $DisposePoshRS_RunspacePools=$False
-        If ($PoshRS_RunspacePools.Count -gt 0) { 
-            #$ParentHost.ui.WriteVerboseLine("$($PoshRS_RunspacePools | Out-String)")           
-            [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) 
-            Foreach($RunspacePool in $PoshRS_RunspacePools) {                
-                #$ParentHost.ui.WriteVerboseLine("RunspacePool <$($RunspacePool.RunspacePoolID)> | MaxJobs: $($RunspacePool.MaxJobs) | AvailJobs: $($RunspacePool.AvailableJobs)")
-                If (($RunspacePool.AvailableJobs -eq $RunspacePool.MaxJobs) -AND $PoshRS_RunspacePools.LastActivity.Ticks -ne 0) {
-                    If ((Get-Date).Ticks - $RunspacePool.LastActivity.Ticks -gt $PoshRS_RunspacePoolCleanup.Timeout) {
-                        #Dispose of runspace pool
-                        $RunspacePool.RunspacePool.Close()
-                        $RunspacePool.RunspacePool.Dispose()
-                        $RunspacePool.CanDispose = $True
-                        $DisposePoshRS_RunspacePools=$True
+        If ($PoshRS_RunspacePools.Count -gt 0) {
+            #$ParentHost.ui.WriteVerboseLine("$($PoshRS_RunspacePools | Out-String)")
+            [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot)
+            try {
+                Foreach($RunspacePool in $PoshRS_RunspacePools) {
+                    #$ParentHost.ui.WriteVerboseLine("RunspacePool <$($RunspacePool.RunspacePoolID)> | MaxJobs: $($RunspacePool.MaxJobs) | AvailJobs: $($RunspacePool.AvailableJobs)")
+                    If (($RunspacePool.AvailableJobs -eq $RunspacePool.MaxJobs) -AND $PoshRS_RunspacePools.LastActivity.Ticks -ne 0) {
+                        If ((Get-Date).Ticks - $RunspacePool.LastActivity.Ticks -gt $PoshRS_RunspacePoolCleanup.Timeout) {
+                            #Dispose of runspace pool
+                            $RunspacePool.RunspacePool.Close()
+                            $RunspacePool.RunspacePool.Dispose()
+                            $RunspacePool.CanDispose = $True
+                            $DisposePoshRS_RunspacePools=$True
+                        }
+                    } Else {
+                        $RunspacePool.LastActivity = (Get-Date)
                     }
-                } Else {
-                    $RunspacePool.LastActivity = (Get-Date)
-                }               
-            }       
-            #Remove runspace pools
-            If ($DisposePoshRS_RunspacePools) {
-                $TempCollection = $PoshRS_RunspacePools.Clone()
-                $TempCollection | Where-Object {
-                    $_.CanDispose
-                } | ForEach-Object {
-                    #$ParentHost.ui.WriteVerboseLine("Removing runspacepool <$($_.RunspacePoolID)>")
-                    [void]$PoshRS_RunspacePools.Remove($_)
                 }
-                #Not setting this to silentlycontinue seems to cause another runspace to be created if an error occurs
-                Remove-Variable TempCollection -ErrorAction SilentlyContinue
+                #Remove runspace pools
+                If ($DisposePoshRS_RunspacePools) {
+                    $TempCollection = $PoshRS_RunspacePools.Clone()
+                    $TempCollection | Where-Object {
+                        $_.CanDispose
+                    } | ForEach-Object {
+                        #$ParentHost.ui.WriteVerboseLine("Removing runspacepool <$($_.RunspacePoolID)>")
+                        [void]$PoshRS_RunspacePools.Remove($_)
+                    }
+                    #Not setting this to silentlycontinue seems to cause another runspace to be created if an error occurs
+                    Remove-Variable TempCollection -ErrorAction SilentlyContinue
+                }
             }
-            [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)
+            finally {
+                [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)
+            }
         }
-            #$ParentHost.ui.WriteVerboseLine("Sleeping")
+        #$ParentHost.ui.WriteVerboseLine("Sleeping")
         If ($DisposePoshRS_RunspacePools) {
             #Perform garbage collection
             [gc]::Collect()
         }
-        Start-Sleep -Milliseconds 5000     
+        Start-Sleep -Milliseconds 5000
     } while ($PoshRS_RunspacePoolCleanup.Flag)
 })
 $PoshRS_RunspacePoolCleanup.PowerShell.Runspace = $PoshRS_RunspacePoolCleanup.Runspace
-$PoshRS_RunspacePoolCleanup.Handle = $PoshRS_RunspacePoolCleanup.PowerShell.BeginInvoke() 
+$PoshRS_RunspacePoolCleanup.Handle = $PoshRS_RunspacePoolCleanup.PowerShell.BeginInvoke()
 #endregion Cleanup Routine
 
 #region Load Public Functions
@@ -293,7 +301,7 @@ $PoshRS_OnRemoveScript = {
     #Let sit for a second to make sure it has had time to stop
     Start-Sleep -Seconds 1
     $PoshRS_jobCleanup.PowerShell.EndInvoke($PoshRS_jobCleanup.Handle)
-    $PoshRS_jobCleanup.PowerShell.Dispose()    
+    $PoshRS_jobCleanup.PowerShell.Dispose()
     $PoshRS_RunspacePoolCleanup.PowerShell.EndInvoke($PoshRS_RunspacePoolCleanup.Handle)
     $PoshRS_RunspacePoolCleanup.PowerShell.Dispose()
     Remove-Variable PoshRS_JobId -Scope Global -Force

--- a/PoshRSJob/PoshRSJob.psm1
+++ b/PoshRSJob/PoshRSJob.psm1
@@ -191,13 +191,14 @@ $PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_Runsp
 $PoshRS_RunspacePoolCleanup.Runspace.SessionStateProxy.SetVariable("ParentHost",$Host) 
 $PoshRS_RunspacePoolCleanup.PowerShell = [PowerShell]::Create().AddScript({
     #Routine to handle completed runspaces
+    $DisposePoshRS_RunspacePools=$False
     Do { 
         #$ParentHost.ui.WriteVerboseLine("Beginning Do Statement")
         If ($DisposePoshRS_RunspacePools) {
             #Perform garbage collection
             [gc]::Collect()
         }
-        $DisposePoshRS_RunspacePools=$False  
+        $DisposePoshRS_RunspacePools=$False
         If ($PoshRS_RunspacePools.Count -gt 0) { 
             #$ParentHost.ui.WriteVerboseLine("$($PoshRS_RunspacePools | Out-String)")           
             [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) 

--- a/PoshRSJob/Public/Get-RSJob.ps1
+++ b/PoshRSJob/Public/Get-RSJob.ps1
@@ -7,14 +7,20 @@ Function Get-RSJob {
             Get-RSJob will display all jobs that are currently available to include completed and currently running jobs.
             If no parameters are given, all jobs are displayed to view.
 
+        .PARAMETER Job
+            Represents the RSJob object being sent to query for.
+
         .PARAMETER Name
             The name of the jobs to query for.
 
         .PARAMETER ID
-            The ID of the jobs that you want to display.
+            The ID of the jobs to query for.
 
         .PARAMETER InstanceID
-            The GUID of the jobs that you want to display.
+            The GUID of the jobs to query for.
+
+        .PARAMETER Batch
+            Name of the set of jobs to query for.
 
         .PARAMETER State
             The State of the job that you want to display. Accepted values are:
@@ -27,16 +33,13 @@ Function Get-RSJob {
             Stopped
             Disconnected
 
-        .PARAMETER Batch 
-            Name of the set of jobs
-
         .PARAMETER HasMoreData
             Displays jobs that have data being outputted. You can specify -HasMoreData:$False to display jobs
-            that have no data to output.            
+            that have no data to output.
 
         .NOTES
             Name: Get-RSJob
-            Author: Boe Prox                
+            Author: Boe Prox/Max Kozlov
 
         .EXAMPLE
             Get-RSJob -State Completed
@@ -64,108 +67,89 @@ Function Get-RSJob {
     )]
     Param (
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='Job', Position=0)]
+        [Alias('InputObject')]
+        [RSJob[]]$Job,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
-        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Guid')]
-        [guid[]]$InstanceID,
-        [parameter(ParameterSetName='Batch')]
-        [parameter(ParameterSetName='Name')]
-        [parameter(ParameterSetName='Id')]
-        [parameter(ParameterSetName='Guid')]
-        [parameter(ParameterSetName='All')]
-        [ValidateSet('NotStarted','Running','Completed','Failed','Stopping','Stopped','Disconnected')]
-        [string[]]$State,
+        [parameter(ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='InstanceID')]
+        [string[]]$InstanceID,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Batch')]
         [string[]]$Batch,
+
         [parameter(ParameterSetName='Batch')]
         [parameter(ParameterSetName='Name')]
         [parameter(ParameterSetName='Id')]
-        [parameter(ParameterSetName='Guid')]
+        [parameter(ParameterSetName='InstanceID')]
         [parameter(ParameterSetName='All')]
-        [Switch]$HasMoreData,
-        [parameter(ValueFromPipeline=$True,ParameterSetName='Job')]
-        [RSJob[]]$Job        
+        [ValidateSet('NotStarted','Running','Completed','Failed','Stopping','Stopped','Disconnected')]
+        [string[]]$State,
+        [parameter(ParameterSetName='Batch')]
+        [parameter(ParameterSetName='Name')]
+        [parameter(ParameterSetName='Id')]
+        [parameter(ParameterSetName='InstanceID')]
+        [parameter(ParameterSetName='All')]
+        [Switch]$HasMoreData
     )
     Begin {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
-        }        
+        }
         Write-Debug "ParameterSet: $($PSCmdlet.parametersetname)"
-        $List = New-Object System.Collections.ArrayList
-        $WhereList = New-Object System.Collections.ArrayList
-        
-        #Take care of bound parameters
-        $Bound = $False
-        If ($PSBoundParameters['Name']) {
-            [void]$list.AddRange($Name)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Batch']) {
-            [void]$list.AddRange($Batch)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Id']) {
-            [void]$list.AddRange($Id)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['InstanceId']) {
-            [void]$list.AddRange($InstanceId)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Job']){
-            [void]$list.AddRange($Job)
-            $Bound = $True
-        }                
+        $Hash = @{}
     }
     Process {
-        If ($PSCmdlet.ParameterSetName -ne 'All' -AND -NOT $Bound) {
-            Write-Verbose "Adding $($_)"
-            [void]$List.Add($_)
+        Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
+        $Property = $PSCmdlet.ParameterSetName
+
+        if ($PSCmdlet.ParameterSetName -eq 'Job') {
+            Write-Verbose "Adding Job $($PSBoundParameters[$Property])"
+            foreach ($v in $PSBoundParameters[$Property]) {
+                $Hash.Add($v.ID,1)
+            }
+        }
+        elseif ($PSCmdlet.ParameterSetName -ne 'All') {
+            Write-Verbose "Adding $($PSBoundParameters[$Property])"
+            foreach ($v in $PSBoundParameters[$Property]) {
+                $Hash.Add($v,1)
+            }
         }
     }
-    End {        
-        Switch ($PSCmdlet.parametersetname) {
-            'Name' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|') -replace '\*','.*'
-                [void]$WhereList.Add("`$_.Name -match $Items")                    
+    End {
+        #Job objects searched by ID
+        if ($Property -eq 'Job') { $Property = 'ID' }
+        # IF faster than any scriptblocks
+        if ($PSCmdlet.ParameterSetName -eq 'All') {
+            $ResultJobs = $PoshRS_Jobs
+        }
+        else {
+            [array]$ResultJobs = foreach ($job in $PoshRS_Jobs) {
+                if ($Hash.ContainsKey($job.$Property)) {
+                    $job
+                }
             }
-            'Id' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$WhereList.Add("`$_.Id -match $Items")                
+        }
+        if ($ResultJobs.Count -and $PSBoundParameters.ContainsKey('State')) {
+            $States = '^' + $State -join '$|^' + '$'
+            [array]$ResultJobs = foreach ($job in $ResultJobs) {
+                if ($job.State -match $States) {
+                    $job
+                }
             }
-            'Guid' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$WhereList.Add("`$_.InstanceId -match $Items")  
+        }
+        if ($ResultJobs.Count -and $PSBoundParameters.ContainsKey('HasMoreData')) {
+            [array]$ResultJobs = foreach ($job in $ResultJobs) {
+                if ($job.HasMoreData -eq $HasMoreData) {
+                    $job
+                }
             }
-            'Job' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_.Id}) -join '|')
-                [void]$WhereList.Add("`$_.id -match $Items")
-            }   
-            'Batch' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$WhereList.Add("`$_.batch -match $Items")
-            }                      
         }
-        If ($PSBoundParameters['State']) {
-            [void]$WhereList.Add("`$_.State -match `"$($State -join '|')`"")
-        }
-        If ($PSBoundParameters.ContainsKey('HasMoreData')) {
-            [void]$WhereList.Add("`$_.HasMoreData -eq `$$HasMoreData")
-        }
-        Write-Debug "WhereListCount: $($WhereList.count)"
-        If ($WhereList.count -gt 0) {
-            $WhereString = $WhereList -join ' -AND '
-            $WhereBlock = [scriptblock]::Create($WhereString)
-            Write-Debug "WhereString: $($WhereString)" 
-            Write-Verbose "Using scriptblock"
-            $PoshRS_Jobs | Where-Object $WhereBlock 
-        } Else {
-            $PoshRS_Jobs
-        }
+        $ResultJobs
     }
 }

--- a/PoshRSJob/Public/Get-RSJob.ps1
+++ b/PoshRSJob/Public/Get-RSJob.ps1
@@ -70,7 +70,7 @@ Function Get-RSJob {
         ParameterSetName='Job', Position=0)]
         [Alias('InputObject')]
         [RSJob[]]$Job,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,

--- a/PoshRSJob/Public/Get-RSJob.ps1
+++ b/PoshRSJob/Public/Get-RSJob.ps1
@@ -71,10 +71,10 @@ Function Get-RSJob {
         [Alias('InputObject')]
         [RSJob[]]$Job,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Name')]
+        ParameterSetName='Name', Position=0)]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Id')]
+        ParameterSetName='Id', Position=0)]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='InstanceID')]

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -81,8 +81,8 @@ Function Receive-RSJob {
         [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        $PSBoundParameters[$Property] = $List
         if (-not $List.Count) { return } # No jobs selected to search
+        $PSBoundParameters[$Property] = $List
         [array]$ToReceive = Get-RSJob @PSBoundParameters
 
         if ($ToReceive.Count) {

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -55,10 +55,10 @@ Function Receive-RSJob {
         ParameterSetName='Job', Position=0)]
         [Alias('InputObject')]
         [RSJob[]]$Job,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -7,8 +7,8 @@ Function Receive-RSJob {
             Gets the results of the Windows PowerShell runspace jobs in the current session. You can use
             Get-RSJob and pipe the results into this function to get the results as well.
 
-        .PARAMETER InputObject
-            Represents the RSJob object being sent to command.
+        .PARAMETER Job
+            Represents the RSJob object to receive available data from.
 
         .PARAMETER Name
             The name of the jobs to receive available data from.
@@ -17,14 +17,14 @@ Function Receive-RSJob {
             The ID of the jobs to receive available data from.
 
         .PARAMETER InstanceID
-            The GUID of the jobs to receive available data from.         
-            
-        .PARAMETER Batch 
-            Name of the set of jobs             
+            The GUID of the jobs to receive available data from.
+
+        .PARAMETER Batch
+            Name of the set of jobs to receive available data from.
 
         .NOTES
             Name: Receive-RSJob
-            Author: Boe Prox                
+            Author: Boe Prox/Max Kozlov
 
         .EXAMPLE
             Get-RSJob -State Completed | Receive-RSJob
@@ -51,117 +51,47 @@ Function Receive-RSJob {
         DefaultParameterSetName='Job'
     )]
     Param (
-        [parameter(Position=0,ValueFromPipeline=$True,ParameterSetName='Job')]
-        [RSJob[]]$InputObject,
-        [parameter(Position=1,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='Job', Position=0)]
+        [Alias('InputObject')]
+        [RSJob[]]$Job,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(Position=2,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
-        [parameter(Position=3,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Guid')]
-        [guid[]]$InstanceID,
-        [parameter(Position=4,ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='InstanceID')]
+        [string[]]$InstanceID,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Batch')]
         [string[]]$Batch
     )
     Begin {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
-        }        
+        }
         $List = New-Object System.Collections.ArrayList
-        $StringBuilder = New-Object System.Text.StringBuilder
-        $Bound = $False
-        $IsInputObject = $False
-
-        #Take care of bound parameters
-        If ($PSBoundParameters['Name']) {
-            [void]$list.AddRange($Name)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Id']) {
-            [void]$list.AddRange($Id)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['InstanceId']) {
-            [void]$list.AddRange($InstanceId)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['InputObject']) {
-            $IsInputObject = $True
-            [void]$list.AddRange($InputObject)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Batch']) {
-            [void]$list.AddRange($Batch)
-            $Bound = $True
-        }
-        Write-Debug "Bound: $Bound"
     }
     Process {
-        If (-NOT $Bound -and $InputObject) {
-            $IsInputObject = $True
-            $_ | WriteStream
-            if (@("Completed", "Failed", "Stopped") -contains $_.State) { 
-                $_ | SetIsReceived -SetTrue
-            }
-        }
-        elseif (-Not $Bound) {
-            [void]$List.Add($_)
-        }
+        Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
+        $Property = $PSCmdlet.ParameterSetName
+        Write-Verbose "Adding $($PSBoundParameters[$Property])"
+        [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        Write-Debug "ParameterSet: $($PSCmdlet.parametersetname)"
-        Switch ($PSCmdlet.parametersetname) {
-            'Name' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|') -replace '\*','.*'
-                [void]$StringBuilder.Append("`$_.Name -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                    
-            }
-            'Id' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.Id -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                
-            }
-            'Guid' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.InstanceId -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())   
-            }
-            'Batch' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.batch -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString()) 
-            } 	
-            Default {$ScriptBlock=$Null}
-        }
-        Write-Debug "ScriptBlock: $($ScriptBlock)"
-        If ($ScriptBlock) {
-            Write-Debug "Running Scriptblock"
-            $PoshRS_jobs | Where-Object $ScriptBlock | ForEach-Object{ 
+        $PSBoundParameters[$Property] = $List
+        if (-not $List.Count) { return } # No jobs selected to search
+        [array]$ToReceive = Get-RSJob @PSBoundParameters
+
+        if ($ToReceive.Count) {
+            $ToReceive | ForEach-Object{
                 $_ | WriteStream
-                if (@("Completed", "Failed", "Stopped") -contains $_.State) { 
-                    $_ | SetIsReceived -SetTrue
-                }
-            }
-        } 
-        ElseIf ($IsInputObject) {
-            $List | ForEach-Object{ 
-                $_ | WriteStream
-                if (@("Completed", "Failed", "Stopped") -contains $_.State) { 
-                    $_ | SetIsReceived -SetTrue
-                }
-            }            
-        }
-        ElseIf ($Bound) {
-            $PoshRS_jobs | ForEach-Object{ 
-                $_ | WriteStream
-                if (@("Completed", "Failed", "Stopped") -contains $_.State) { 
+                if (@("Completed", "Failed", "Stopped") -contains $_.State) {
                     $_ | SetIsReceived -SetTrue
                 }
             }
         }
     }
 }
-

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -56,10 +56,10 @@ Function Receive-RSJob {
         [Alias('InputObject')]
         [RSJob[]]$Job,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Name')]
+        ParameterSetName='Name', Position=0)]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Id')]
+        ParameterSetName='Id', Position=0)]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='InstanceID')]

--- a/PoshRSJob/Public/Receive-RSJob.ps1
+++ b/PoshRSJob/Public/Receive-RSJob.ps1
@@ -77,8 +77,10 @@ Function Receive-RSJob {
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
         $Property = $PSCmdlet.ParameterSetName
-        Write-Verbose "Adding $($PSBoundParameters[$Property])"
-        [void]$List.AddRange($PSBoundParameters[$Property])
+        if ($PSBoundParameters[$Property]) {
+            Write-Verbose "Adding $($PSBoundParameters[$Property])"
+            [void]$List.AddRange($PSBoundParameters[$Property])
+        }
     }
     End {
         if (-not $List.Count) { return } # No jobs selected to search

--- a/PoshRSJob/Public/Remove-RSJob.ps1
+++ b/PoshRSJob/Public/Remove-RSJob.ps1
@@ -76,8 +76,10 @@ Function Remove-RSJob {
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
         $Property = $PSCmdlet.ParameterSetName
-        Write-Verbose "Adding $($PSBoundParameters[$Property])"
-        [void]$List.AddRange($PSBoundParameters[$Property])
+        if ($PSBoundParameters[$Property]) {
+            Write-Verbose "Adding $($PSBoundParameters[$Property])"
+            [void]$List.AddRange($PSBoundParameters[$Property])
+        }
     }
     End {
         if (-not $List.Count) { return } # No jobs selected to search

--- a/PoshRSJob/Public/Remove-RSJob.ps1
+++ b/PoshRSJob/Public/Remove-RSJob.ps1
@@ -80,8 +80,8 @@ Function Remove-RSJob {
         [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        $PSBoundParameters[$Property] = $List
         if (-not $List.Count) { return } # No jobs selected to search
+        $PSBoundParameters[$Property] = $List
         [void]$PSBoundParameters.Remove('Force')
         [array]$ToRemove = Get-RSJob @PSBoundParameters
         if ($ToRemove.Count) {

--- a/PoshRSJob/Public/Remove-RSJob.ps1
+++ b/PoshRSJob/Public/Remove-RSJob.ps1
@@ -51,10 +51,10 @@ Function Remove-RSJob {
         ParameterSetName='Job', Position=0)]
         [Alias('InputObject')]
         [RSJob[]]$Job,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,

--- a/PoshRSJob/Public/Remove-RSJob.ps1
+++ b/PoshRSJob/Public/Remove-RSJob.ps1
@@ -52,10 +52,10 @@ Function Remove-RSJob {
         [Alias('InputObject')]
         [RSJob[]]$Job,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Name')]
+        ParameterSetName='Name', Position=0)]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Id')]
+        ParameterSetName='Id', Position=0)]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='InstanceID')]

--- a/PoshRSJob/Public/Remove-RSJob.ps1
+++ b/PoshRSJob/Public/Remove-RSJob.ps1
@@ -6,6 +6,9 @@ Function Remove-RSJob {
         .DESCRIPTION
             Deletes a Windows PowerShell background job that has been started using Start-RSJob
 
+        .PARAMETER Job
+            The job object to remove.
+
         .PARAMETER Name
             The name of the jobs to remove..
 
@@ -15,18 +18,15 @@ Function Remove-RSJob {
         .PARAMETER InstanceID
             The GUID of the jobs to remove.
 
-        .PARAMETER Batch 
-            Name of the set of jobs
-            
-        .PARAMETER Job
-            The job object to remove.  
-            
+        .PARAMETER Batch
+            Name of the set of jobs to remove.
+
         .PARAMETER Force
-            Force a running job to stop prior to being removed.        
+            Force a running job to stop prior to being removed.
 
         .NOTES
             Name: Remove-RSJob
-            Author: Boe Prox                
+            Author: Boe Prox/Max Kozlov
 
         .EXAMPLE
             Get-RSJob -State Completed | Remove-RSJob
@@ -48,103 +48,59 @@ Function Remove-RSJob {
     )]
     Param (
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='Job', Position=0)]
+        [Alias('InputObject')]
+        [RSJob[]]$Job,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
-        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Guid')]
-        [guid[]]$InstanceID,
+        [parameter(ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='InstanceID')]
+        [string[]]$InstanceID,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Batch')]
         [string[]]$Batch,
-        [parameter(ValueFromPipeline=$True,ParameterSetName='Job')]
-        [RSJob[]]$Job,
+
         [parameter()]
         [switch]$Force
     )
-    Begin {        
+    Begin {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
-        }      
+        }
         $List = New-Object System.Collections.ArrayList
-        $StringBuilder = New-Object System.Text.StringBuilder
-
-        #Take care of bound parameters
-        $Bound = $False
-        If ($PSBoundParameters['Name']) {
-            [void]$list.AddRange($Name)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Batch']) {
-            [void]$list.AddRange($Batch)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Id']) {
-            [void]$list.AddRange($Id)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['InstanceId']) {
-            [void]$list.AddRange($InstanceId)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Job']) {
-            [void]$list.AddRange($Job)
-            $Bound = $True
-        }
     }
     Process {
-        If (-Not $Bound) {
-            [void]$List.Add($_)
-        }
+        Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
+        $Property = $PSCmdlet.ParameterSetName
+        Write-Verbose "Adding $($PSBoundParameters[$Property])"
+        [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        Write-Debug "ParameterSet: $($PSCmdlet.parametersetname)"
-        Switch ($PSCmdlet.parametersetname) {
-            'Name' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|') -replace '\*','.*'
-                [void]$StringBuilder.Append("`$_.Name -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                    
-            }
-            'Id' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.Id -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                
-            }
-            'Guid' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.InstanceId -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())   
-            }
-            'Batch' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.batch -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())   
-            } 	
-            Default {$ScriptBlock=$Null}
-        }
-        If ($ScriptBlock) {
-            Write-Verbose "Using ScriptBlock"
-            $ToRemove = $PoshRS_jobs | Where-Object $ScriptBlock
-        } Else {
-            $ToRemove = $List
-        }
-        [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot) 
-        $ToRemove | ForEach-Object {
-            If ($PSCmdlet.ShouldProcess("Name: $($_.Name), associated with JobID $($_.Id)",'Remove')) {
-                If ($_.State -notmatch 'Completed|Failed|Stopped') {
-                    If ($PSBoundParameters.ContainsKey('Force')) {
-                        [void] $_.InnerJob.Stop()
-                        $PoshRS_Jobs.Remove($_)
+        $PSBoundParameters[$Property] = $List
+        if (-not $List.Count) { return } # No jobs selected to search
+        [void]$PSBoundParameters.Remove('Force')
+        [array]$ToRemove = Get-RSJob @PSBoundParameters
+        if ($ToRemove.Count) {
+            [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot)
+            $ToRemove | ForEach-Object {
+                If ($PSCmdlet.ShouldProcess("Name: $($_.Name), associated with JobID $($_.Id)",'Remove')) {
+                    If ($_.State -notmatch 'Completed|Failed|Stopped') {
+                        If ($Force) {
+                            [void] $_.InnerJob.Stop()
+                            $PoshRS_Jobs.Remove($_)
+                        } Else {
+                            Write-Error "Unable to remove job $($_.InstanceID)"
+                        }
                     } Else {
-                        Write-Error "Unable to remove job $($_.InstanceID)"
+                        [void]$PoshRS_Jobs.Remove($_)
                     }
-                } Else {
-                    [void]$PoshRS_Jobs.Remove($_)
                 }
             }
+            [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot)
         }
-        [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot) 
     }
 }

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -190,8 +190,8 @@ Function Start-RSJob {
         }
         If ($PSBoundParameters.ContainsKey('Name')) {
             If ($Name -isnot [scriptblock]) {
-                $JobName = [scriptblock]::Create("Write-Output $Name")
-            } 
+                $JobName = [scriptblock]::Create("Write-Output `"$Name`"")
+            }
             Else {
                 $JobName = [scriptblock]::Create( ($Name -replace '\$_','$Item'))
             }

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -44,7 +44,7 @@ Function Start-RSJob {
 
         .NOTES
             Name: Start-RSJob
-            Author: Boe Prox                
+            Author: Boe Prox
 
         .EXAMPLE
             Get-ChildItem -Directory | Start-RSjob -Name {$_.Name} -ScriptBlock {
@@ -56,8 +56,8 @@ Function Start-RSJob {
                     Name = $Directory.Name
                     SizeMB = ([math]::round(($Sum/1MB),2))
                 }
-            } 
-            
+            }
+
             Id  Name                 State           HasMoreData  HasErrors    Command
             --  ----                 -----           -----------  ---------    -------
             13  Contacts             Running         False        False        ...
@@ -92,8 +92,8 @@ Function Start-RSJob {
 
             Description
             -----------
-            Starts a background runspace job that looks at the total size of each folder. Using Get-RSJob | Recieve-RSJob shows 
-            the results when the State is Completed.         
+            Starts a background runspace job that looks at the total size of each folder. Using Get-RSJob | Recieve-RSJob shows
+            the results when the State is Completed.
 
         .EXAMPLE
             $Test = 'test'
@@ -104,7 +104,7 @@ Function Start-RSJob {
                     Test=$Using:Test
                     Something=$Using:Something
                 }
-            }            
+            }
 
             Id  Name                 State           HasMoreData  HasErrors    Command
             --  ----                 -----           -----------  ---------    -------
@@ -113,7 +113,7 @@ Function Start-RSJob {
             78  3                    Running         False        False        ...
             79  4                    Completed       False        False        ...
             80  5                    Completed       False        False        ...
-            
+
             Get-RSjob | Receive-RSJob
 
             Result Test Something
@@ -123,7 +123,7 @@ Function Start-RSJob {
                  6 test {1, 2, 3, 4...}
                  8 test {1, 2, 3, 4...}
                 10 test {1, 2, 3, 4...}
-            
+
             Description
             -----------
             Shows an example of the $Using: variable being used in the scriptblock.
@@ -145,7 +145,7 @@ Function Start-RSJob {
             }
 
             1..5|Start-RSJob $ScriptBlock -ArgumentList $test, $anothertest
-            
+
             Description
             -----------
             Shows an example of the $Using: variable being used in the scriptblock as well as $_ and multiple -ArgumentList parameters.
@@ -177,11 +177,11 @@ Function Start-RSJob {
         [parameter()]
         [string[]]$FunctionsToLoad
     )
-    Begin {               
+    Begin {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
-        } 
-        Write-Debug "[BEGIN]"   
+        }
+        Write-Debug "[BEGIN]"
         If ($PSBoundParameters.ContainsKey('Verbose')) {
             Write-Verbose "Displaying PSBoundParameters"
             $PSBoundParameters.GetEnumerator() | ForEach-Object {
@@ -195,11 +195,11 @@ Function Start-RSJob {
             Else {
                 $JobName = [scriptblock]::Create( ($Name -replace '\$_','$Item'))
             }
-        } 
+        }
         Else {
             Write-Verbose "Creating default Job Name"
             $JobName = [scriptblock]::Create('Write-Output Job$($Id)')
-        }              
+        }
         $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
         If ($PSBoundParameters['ModulesToImport']) {
             [void]$InitialSessionState.ImportPSModule($ModulesToImport)
@@ -217,8 +217,8 @@ Function Start-RSJob {
                     $Definition = Get-Content Function:\$Function -ErrorAction Stop
                     Write-Debug "Definition: $($Definition)"
                     $SessionStateFunction = New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $Function, $Definition
-                    $InitialSessionState.Commands.Add($SessionStateFunction) 
-                } 
+                    $InitialSessionState.Commands.Add($SessionStateFunction)
+                }
                 Catch {
                     Write-Warning "$($Function): $($_.Exception.Message)"
                 }
@@ -228,13 +228,13 @@ Function Start-RSJob {
                     $AliasEntry = New-Object System.Management.Automation.Runspaces.SessionStateAliasEntry -ArgumentList $Alias.Name,$Alias.Definition
                     $InitialSessionState.Commands.Add($AliasEntry)
                 }
-            }           
+            }
         }
         If ($PSBoundParameters.ContainsKey('ArgumentList')) {
             Write-Debug "$(@($ArgumentList).count) argument/s passed via -ArgumentList"
             If (@($ArgumentList).count -le 1) {
                 $SingleArgument = $True
-            } 
+            }
             Else {
                 $SingleArgument = $False
             }
@@ -244,18 +244,18 @@ Function Start-RSJob {
         }
 
         $Script:List = New-Object System.Collections.ArrayList
-        If ($PSBoundParameters.ContainsKey('InputObject')) {            
-            [void]$list.AddRange(@($InputObject))    
+        If ($PSBoundParameters.ContainsKey('InputObject')) {
+            [void]$list.AddRange(@($InputObject))
             $IsPipeline = $True
             $IgnoreProcess = $True
-        } 
+        }
         ElseIf ($PSCmdlet.SessionState.PSVariable.Get('_') -AND $PSVersionTable.PSVersion.Major -ne2) {
             Write-Debug '$_ found from ForEach loop'
             $IsPipeline = $True
             $IgnoreProcess = $False
             #[void]$list.AddRange(@($PSCmdlet.SessionState.PSVariable.Get('_') | Select-Object -ExpandProperty Value))
             Try {
-                $InputObject = $PSBoundParameters['InputObject'] = @($PSCmdlet.SessionState.PSVariable.Get('_') | 
+                $InputObject = $PSBoundParameters['InputObject'] = @($PSCmdlet.SessionState.PSVariable.Get('_') |
                 Select-Object -ExpandProperty Value)
             }
             Catch {
@@ -268,10 +268,10 @@ Function Start-RSJob {
         }
     }
     Process {
-        Write-Debug "[PROCESS]"       
+        Write-Debug "[PROCESS]"
         If ($IsPipeline -AND $PSBoundParameters.ContainsKey('InputObject') -AND -NOT $IgnoreProcess) {
             [void]$List.Add($InputObject)
-        } 
+        }
         ElseIf ($IgnoreProcess) {
             $IsPipeline = $True
         }
@@ -279,19 +279,19 @@ Function Start-RSJob {
             $IsPipeline = $True
         }
     }
-    End { 
-        Write-Debug "[END]"        
+    End {
+        Write-Debug "[END]"
         $SBParamCount = @(GetParamVariable -ScriptBlock $ScriptBlock).Count
         $ArgumentCount = If (-NOT $ArgumentList -or ($SingleArgument -eq 0)) { # Empty array, or, 0 count
             0
-        } 
+        }
         Else {
             @($ArgumentList).count
         }
         If ($PSBoundParameters.ContainsKey('InputObject')) {
             If ($ArgumentCount -gt 0) {
                 $SBParamCount++
-            } 
+            }
             Else {
                 $SBParamCount--
             }
@@ -300,7 +300,7 @@ Function Start-RSJob {
         If ($ArgumentCount -ne $SBParamCount -AND $IsPipeline) {
             Write-Verbose 'Will use $_ in Param() Block'
             $Script:Add_ = $True
-        } 
+        }
         Else {
             $Script:Add_ = $False
         }
@@ -312,7 +312,7 @@ Function Start-RSJob {
         Switch ($PSVersionTable.PSVersion.Major) {
             2 {
                 Write-Verbose "Using PSParser with PowerShell V2"
-                $UsingVariables = @(GetUsingVariablesV2 -ScriptBlock $ScriptBlock)                
+                $UsingVariables = @(GetUsingVariablesV2 -ScriptBlock $ScriptBlock)
                 Write-Verbose "Using Count: $($UsingVariables.count)"
                 Write-Verbose "$($UsingVariables|Out-String)"
                 Write-Verbose "CommandOrigin: $($MyInvocation.CommandOrigin)"
@@ -322,7 +322,7 @@ Function Start-RSJob {
                         Try {
                             If ($MyInvocation.CommandOrigin -eq 'Runspace') {
                                 $Value = (Get-Variable -Name $Name).Value
-                            } 
+                            }
                             Else {
                                 $Value = $PSCmdlet.SessionState.PSVariable.Get($Name).Value
                                 If ([string]::IsNullOrEmpty($Value)) {
@@ -335,35 +335,35 @@ Function Start-RSJob {
                                 Value = $Value
                                 NewVarName = ('__using_{0}') -f $Name
                             }
-                        } 
+                        }
                         Catch {
-                            Throw "Start-RSJob : The value of the using variable '$($Var.SubExpression.Extent.Text)' cannot be retrieved because it has not been set in the local session."                        
+                            Throw "Start-RSJob : The value of the using variable '$($Var.SubExpression.Extent.Text)' cannot be retrieved because it has not been set in the local session."
                         }
                     })
 
                     Write-Verbose ("Found {0} `$Using: variables!" -f $UsingVariableValues.count)
                 }
                 If ($UsingVariables.count -gt 0 -OR $Script:Add_) {
-                    $NewScriptBlock = ConvertScriptBlockV2 $ScriptBlock -UsingVariable $UsingVariables -UsingVariableValue $UsingVariableValues           
-                } 
+                    $NewScriptBlock = ConvertScriptBlockV2 $ScriptBlock -UsingVariable $UsingVariables -UsingVariableValue $UsingVariableValues
+                }
                 Else {
                     $NewScriptBlock = $ScriptBlock
-                }                
+                }
             }
             Default {
                 Write-Debug "Using AST with PowerShell V3+"
                 $UsingVariables = @(GetUsingVariables $ScriptBlock | Group-Object SubExpression | ForEach-Object {
                     $_.Group | Select-Object -First 1
-                })    
-                #region Get Variable Values            
+                })
+                #region Get Variable Values
                 If ($UsingVariables.count -gt 0) {
-                    $UsingVar = $UsingVariables | Group-Object SubExpression | ForEach-Object {$_.Group | Select-Object -First 1}  
-                    Write-Debug "CommandOrigin: $($MyInvocation.CommandOrigin)"      
+                    $UsingVar = $UsingVariables | Group-Object SubExpression | ForEach-Object {$_.Group | Select-Object -First 1}
+                    Write-Debug "CommandOrigin: $($MyInvocation.CommandOrigin)"
                     $UsingVariableValues = @(ForEach ($Var in $UsingVar) {
                         Try {
                             If ($MyInvocation.CommandOrigin -eq 'Runspace') {
                                 $Value = Get-Variable -Name $Var.SubExpression.VariablePath.UserPath
-                            } 
+                            }
                             Else {
                                 $Value = ($PSCmdlet.SessionState.PSVariable.Get($Var.SubExpression.VariablePath.UserPath))
                                 If ([string]::IsNullOrEmpty($Value)) {
@@ -376,7 +376,7 @@ Function Start-RSJob {
                                 NewName = ('$__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
                                 NewVarName = ('__using_{0}' -f $Var.SubExpression.VariablePath.UserPath)
                             }
-                        } 
+                        }
                         Catch {
                             Throw "Start-RSJob : The value of the using variable '$($Var.SubExpression.Extent.Text)' cannot be retrieved because it has not been set in the local session."
                         }
@@ -385,8 +385,8 @@ Function Start-RSJob {
                     Write-Verbose ("Found {0} `$Using: variables!" -f $UsingVariableValues.count)
                 }
                 If ($UsingVariables.count -gt 0 -OR $Script:Add_) {
-                    $NewScriptBlock = ConvertScript $ScriptBlock            
-                } 
+                    $NewScriptBlock = ConvertScript $ScriptBlock
+                }
                 Else {
                     $NewScriptBlock = $ScriptBlock
                 }
@@ -397,49 +397,53 @@ Function Start-RSJob {
 
         Write-Debug "ScriptBlock: $($NewScriptBlock)"
 
-        #region RunspacePool Creation        
-                
-            [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) 
-            $__RSPObject = $PoshRS_RunspacePools | Where-Object {
-                $_.RunspacePoolID -eq $Batch
-            }
-            If ($__RSPObject) {
-                Write-Verbose "Using current runspacepool <$($__RSPObject.RunspacePoolID)>"
-                $RunspacePoolID = $__RSPObject.RunspacePoolID
-                $RSPObject = $__RSPObject
-                $RSPObject.LastActivity = Get-Date
-            }
-            Else {
-                Write-Verbose "Creating new runspacepool <$Batch>"
-                $RunspacePoolID = $Batch
-                $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
-                If ($RunspacePool.psobject.Properties["ApartmentState"]) {
-                    #ApartmentState doesn't exist in Nano Server
-                    $RunspacePool.ApartmentState = 'STA'
-                } 
-                [void]$RunspacePool.SetMaxRunspaces($Throttle)
-                If ($PSVersionTable.PSVersion.Major -gt 2) {
-                    $RunspacePool.CleanupInterval = [timespan]::FromMinutes(2)    
+        #region RunspacePool Creation
+
+            [System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot)
+            try {
+                $__RSPObject = $PoshRS_RunspacePools | Where-Object {
+                    $_.RunspacePoolID -eq $Batch
                 }
-                $RunspacePool.Open()
-                $RSPObject = New-Object RSRunspacePool -Property @{
-                    RunspacePool = $RunspacePool
-                    MaxJobs = $RunspacePool.GetMaxRunspaces()
-                    RunspacePoolID = $RunspacePoolID
-                    LastActivity = Get-Date
+                If ($__RSPObject) {
+                    Write-Verbose "Using current runspacepool <$($__RSPObject.RunspacePoolID)>"
+                    $RunspacePoolID = $__RSPObject.RunspacePoolID
+                    $RSPObject = $__RSPObject
+                    $RSPObject.LastActivity = Get-Date
                 }
-                
-                #[System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
-                [void]$PoshRS_RunspacePools.Add($RSPObject)
+                Else {
+                    Write-Verbose "Creating new runspacepool <$Batch>"
+                    $RunspacePoolID = $Batch
+                    $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
+                    If ($RunspacePool.psobject.Properties["ApartmentState"]) {
+                        #ApartmentState doesn't exist in Nano Server
+                        $RunspacePool.ApartmentState = 'STA'
+                    }
+                    [void]$RunspacePool.SetMaxRunspaces($Throttle)
+                    If ($PSVersionTable.PSVersion.Major -gt 2) {
+                        $RunspacePool.CleanupInterval = [timespan]::FromMinutes(2)
+                    }
+                    $RunspacePool.Open()
+                    $RSPObject = New-Object RSRunspacePool -Property @{
+                        RunspacePool = $RunspacePool
+                        MaxJobs = $RunspacePool.GetMaxRunspaces()
+                        RunspacePoolID = $RunspacePoolID
+                        LastActivity = Get-Date
+                    }
+
+                    #[System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
+                    [void]$PoshRS_RunspacePools.Add($RSPObject)
+                }
             }
-            [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)            
+            finally {
+                [System.Threading.Monitor]::Exit($PoshRS_RunspacePools.syncroot)
+            }
         #endregion RunspacePool Creation
 
         If ($List.Count -gt 0) {
             Write-Debug "InputObject"
             Write-Debug "ListCount: $($list.count)"
             ForEach ($Item in $list) {
-                $ID = Increment                    
+                $ID = Increment
                 Write-Verbose "Using $($Item) as pipeline variable"
                 $PowerShell = [powershell]::Create().AddScript($NewScriptBlock)
                 $PowerShell.RunspacePool = $RSPObject.RunspacePool
@@ -453,16 +457,16 @@ Function Start-RSJob {
                 }
                 Write-Verbose "Checking for ArgumentList"
                 If ($PSBoundParameters.ContainsKey('ArgumentList')) {
-                    If ($SingleArgument) {                        
+                    If ($SingleArgument) {
                         ,$ArgumentList | ForEach-Object {
                             Write-Verbose "Adding Argument: $($_) <$($_.GetType().Fullname)>"
-                            [void]$PowerShell.AddArgument($_) 
+                            [void]$PowerShell.AddArgument($_)
                         }
-                    } 
+                    }
                     Else {
                         ForEach ($Argument in $ArgumentList) {
                             Write-Verbose "Adding Argument: $($Argument) <$($Argument.GetType().Fullname)>"
-                            [void]$PowerShell.AddArgument($Argument)    
+                            [void]$PowerShell.AddArgument($Argument)
                         }
                     }
                 }
@@ -471,7 +475,7 @@ Function Start-RSJob {
                 Write-Verbose "Determining Job Name"
                 $_JobName = If ($PSVersionTable.PSVersion.Major -eq 2) {
                     $JobName.Invoke()
-                } 
+                }
                 Else {
                     $JobName.InvokeReturnAsIs()
                 }
@@ -479,7 +483,7 @@ Function Start-RSJob {
                     Name = $_JobName
                     InputObject = $Item
                     InstanceID = [guid]::NewGuid().ToString()
-                    ID = $ID  
+                    ID = $ID
                     Handle = $Handle
                     InnerJob = $PowerShell
                     Runspace = $PowerShell.Runspace
@@ -488,19 +492,19 @@ Function Start-RSJob {
                     RunspacePoolID = $RunSpacePoolID
                     Batch = $Batch
                 }
-                
+
                 $RSPObject.LastActivity = Get-Date
                 Write-Verbose "Adding RSJob to Jobs queue"
-                [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot) 
+                [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot)
                 [void]$PoshRS_Jobs.Add($Object)
-                [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot) 
+                [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot)
                 Write-Verbose "Display RSJob"
-                $Object            
+                $Object
             }
-        } 
+        }
         Else {
             Write-Debug "No InputObject"
-            $ID = Increment                    
+            $ID = Increment
             $PowerShell = [powershell]::Create().AddScript($NewScriptBlock)
             $PowerShell.RunspacePool = $RSPObject.RunspacePool
             If ($UsingVariableValues) {
@@ -513,20 +517,20 @@ Function Start-RSJob {
                 If ($SingleArgument) {
                     ,$ArgumentList | ForEach-Object {
                         Write-Verbose "Adding Argument: $($_) <$($_.GetType().Fullname)>"
-                        [void]$PowerShell.AddArgument($_) 
+                        [void]$PowerShell.AddArgument($_)
                     }
-                } 
+                }
                 Else {
                     ForEach ($Argument in $ArgumentList) {
                         Write-Verbose "Adding Argument: $($Argument) <$($Argument.GetType().Fullname)>"
-                        [void]$PowerShell.AddArgument($Argument)    
+                        [void]$PowerShell.AddArgument($Argument)
                     }
                 }
             }
             $Handle = $PowerShell.BeginInvoke()
             $_JobName = If ($PSVersionTable.PSVersion.Major -eq 2) {
                 $JobName.Invoke()
-            } 
+            }
             Else {
                 $JobName.InvokeReturnAsIs()
             }
@@ -534,7 +538,7 @@ Function Start-RSJob {
                 Name = $_JobName
                 InputObject = $null
                 InstanceID = [guid]::NewGuid().ToString()
-                ID = $ID  
+                ID = $ID
                 Handle = $Handle
                 InnerJob = $PowerShell
                 Runspace = $PowerShell.Runspace
@@ -543,12 +547,12 @@ Function Start-RSJob {
                 RunspacePoolID = $RunSpacePoolID
                 Batch = $Batch
             }
-            
+
             $RSPObject.LastActivity = Get-Date
-            [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot) 
+            [System.Threading.Monitor]::Enter($PoshRS_Jobs.syncroot)
             [void]$PoshRS_Jobs.Add($Object)
-            [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot) 
-            $Object        
-        }      
+            [System.Threading.Monitor]::Exit($PoshRS_Jobs.syncroot)
+            $Object
+        }
     }
 }

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -79,14 +79,18 @@ Function Stop-RSJob {
 
         If ($ToStop.Count) {
             [System.Threading.Monitor]::Enter($PoshRS_jobs.syncroot)
-            $ToStop | ForEach-Object {
-                Write-Verbose "Stopping $($_.InstanceId)"
-                if ($_.State -ne 'Completed') {
-                    Write-Verbose "Killing job $($_.InstanceId)"
-                    [void] $_.InnerJob.Stop()
+            try {
+                $ToStop | ForEach-Object {
+                    Write-Verbose "Stopping $($_.InstanceId)"
+                    if ($_.State -ne 'Completed') {
+                        Write-Verbose "Killing job $($_.InstanceId)"
+                        [void] $_.InnerJob.Stop()
+                    }
                 }
             }
-            [System.Threading.Monitor]::Exit($PoshRS_jobs.syncroot)
+            finally {
+                [System.Threading.Monitor]::Exit($PoshRS_jobs.syncroot)
+            }
         }
     }
 }

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -48,10 +48,10 @@ Function Stop-RSJob {
         [Alias('InputObject')]
         [RSJob[]]$Job,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Name')]
+        ParameterSetName='Name', Position=0)]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Id')]
+        ParameterSetName='Id', Position=0)]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='InstanceID')]

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -69,8 +69,10 @@ Function Stop-RSJob {
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
         $Property = $PSCmdlet.ParameterSetName
-        Write-Verbose "Adding $($PSBoundParameters[$Property])"
-        [void]$List.AddRange($PSBoundParameters[$Property])
+        if ($PSBoundParameters[$Property]) {
+            Write-Verbose "Adding $($PSBoundParameters[$Property])"
+            [void]$List.AddRange($PSBoundParameters[$Property])
+        }
     }
     End {
         if (-not $List.Count) { return } # No jobs selected to search

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -47,10 +47,10 @@ Function Stop-RSJob {
         ParameterSetName='Job', Position=0)]
         [Alias('InputObject')]
         [RSJob[]]$Job,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -73,8 +73,8 @@ Function Stop-RSJob {
         [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        $PSBoundParameters[$Property] = $List
         if (-not $List.Count) { return } # No jobs selected to search
+        $PSBoundParameters[$Property] = $List
         [array]$ToStop = Get-RSJob @PSBoundParameters
 
         If ($ToStop.Count) {

--- a/PoshRSJob/Public/Stop-RSJob.ps1
+++ b/PoshRSJob/Public/Stop-RSJob.ps1
@@ -6,6 +6,9 @@ Function Stop-RSJob {
         .DESCRIPTION
             Stops a Windows PowerShell background job that has been started using Start-RSJob
 
+        .PARAMETER Job
+            The job object to stop.
+
         .PARAMETER Name
             The name of the jobs to stop..
 
@@ -14,16 +17,13 @@ Function Stop-RSJob {
 
         .PARAMETER InstanceID
             The GUID of the jobs to stop.
-            
-        .PARAMETER Job
-            The job object to stop.  
-            
-        .PARAMETER Batch 
-            Name of the set of jobs                   
+
+        .PARAMETER Batch
+            Name of the set of jobs to stop.
 
         .NOTES
             Name: Stop-RSJob
-            Author: Boe Prox                
+            Author: Boe Prox/Max Kozlov
 
         .EXAMPLE
             Get-RSJob -State Completed | Stop-RSJob
@@ -44,92 +44,42 @@ Function Stop-RSJob {
     )]
     Param (
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='Job', Position=0)]
+        [Alias('InputObject')]
+        [RSJob[]]$Job,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
-        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Guid')]
-        [guid[]]$InstanceID,
+        [parameter(ValueFromPipelineByPropertyName=$True,
+        ParameterSetName='InstanceID')]
+        [string[]]$InstanceID,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Batch')]
-        [string[]]$Batch,
-        [parameter(ValueFromPipeline=$True,ParameterSetName='Job')]
-        [RSJob[]]$Job
+        [string[]]$Batch
     )
-    Begin {        
+    Begin {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
-        }  
-        Write-Debug "Begin"      
+        }
         $List = New-Object System.Collections.ArrayList
-        $StringBuilder = New-Object System.Text.StringBuilder
-
-        #Take care of bound parameters
-        $Bound = $False
-        If ($PSBoundParameters['Name']) {
-            [void]$list.AddRange($Name)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Id']) {
-            [void]$list.AddRange($Id)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['InstanceId']) {
-            [void]$list.AddRange($InstanceId)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Job']) {
-            [void]$list.AddRange($Job)
-            $Bound = $True
-        }
-        If ($PSBoundParameters['Batch']) {
-            [void]$list.AddRange($Batch)
-            $Bound = $True
-        }
-        Write-Debug "Process"
     }
     Process {
-        If (-Not $Bound) {
-            [void]$List.Add($_)
-        }
+        Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
+        $Property = $PSCmdlet.ParameterSetName
+        Write-Verbose "Adding $($PSBoundParameters[$Property])"
+        [void]$List.AddRange($PSBoundParameters[$Property])
     }
     End {
-        Write-Debug "End"
-        Write-Debug "ParameterSet: $($PSCmdlet.parametersetname)"
-        Switch ($PSCmdlet.parametersetname) {
-            'Name' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|') -replace '\*','.*'
-                [void]$StringBuilder.Append("`$_.Name -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                    
-            }
-            'Id' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.Id -match $Items") 
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())                
-            }
-            'Guid' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.InstanceId -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString())   
-            }
-            'Batch' {
-                $Items = '"{0}"' -f (($list | ForEach-Object {"^{0}$" -f $_}) -join '|')
-                [void]$StringBuilder.Append("`$_.batch -match $Items")   
-                $ScriptBlock = [scriptblock]::Create($StringBuilder.ToString()) 
-            } 	
-            Default {$ScriptBlock=$Null}
-        }
-        If ($ScriptBlock) {
-            Write-Verbose "Using ScriptBlock"
-            $ToStop = $PoshRS_jobs | Where-Object $ScriptBlock
-        } Else {
-            $ToStop = $List
-        }
-        If ($ToStop) {
-            [System.Threading.Monitor]::Enter($PoshRS_jobs.syncroot)         
-            $ToStop | ForEach-Object {            
+        $PSBoundParameters[$Property] = $List
+        if (-not $List.Count) { return } # No jobs selected to search
+        [array]$ToStop = Get-RSJob @PSBoundParameters
+
+        If ($ToStop.Count) {
+            [System.Threading.Monitor]::Enter($PoshRS_jobs.syncroot)
+            $ToStop | ForEach-Object {
                 Write-Verbose "Stopping $($_.InstanceId)"
                 if ($_.State -ne 'Completed') {
                     Write-Verbose "Killing job $($_.InstanceId)"
@@ -138,5 +88,5 @@ Function Stop-RSJob {
             }
             [System.Threading.Monitor]::Exit($PoshRS_jobs.syncroot)
         }
-    }  
+    }
 }

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -126,7 +126,7 @@ Function Wait-RSJob {
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
         if ($IsPipeline) {
-	        $Property = $PSCmdlet.ParameterSetName
+            $Property = $PSCmdlet.ParameterSetName
             if ($PSCmdlet.ParameterSetName -eq 'Job') {
                 [void]$WaitJobs.AddRange($Job)
             }
@@ -146,21 +146,21 @@ Function Wait-RSJob {
         if ($PSBoundParameters.ContainsKey('HasMoreData')) {
             [void]$WhereList.Add("`$_.HasMoreData -eq `$$HasMoreData")
         }
-		# IF faster than any scriptblocks
+        # IF faster than any scriptblocks
         if ($PSCmdlet.ParameterSetName -ne 'Job') {
-			if ($PSCmdlet.ParameterSetName -eq 'All') {
-				$WaitJobs = $PoshRS_Jobs
-			}
-			else {
-	            foreach ($job in $PoshRS_Jobs) {
-    	            if ($Hash.ContainsKey($job.$Property)) {
-        	            [void]$WaitJobs.Add($job)
-            	    }
-	            }
+            if ($PSCmdlet.ParameterSetName -eq 'All') {
+                $WaitJobs = $PoshRS_Jobs
+            }
+            else {
+                foreach ($job in $PoshRS_Jobs) {
+                    if ($Hash.ContainsKey($job.$Property)) {
+                        [void]$WaitJobs.Add($job)
+                    }
+                }
             }
         }
         if ($WaitJobs.Count -and $PSBoundParameters.ContainsKey('State')) {
-			$States = '^' + $State -join '$|^' + '$'
+            $States = '^' + $State -join '$|^' + '$'
             $WaitJobs = foreach ($job in $WaitJobs) {
                 if ($job.State -match $States) {
                     $job

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -41,8 +41,7 @@ Function Wait-RSJob {
 
         .NOTES
             Name: Wait-RSJob
-            Author: Ryan Bushe/Boe Prox
-        Notes: This function is a slightly modified version of Get-RSJob by Boe Prox.(~10 lines of code changed)
+            Author: Ryan Bushe/Boe Prox/Max Kozlov
 
         .EXAMPLE
             Get-RSJob | Wait-RSJob
@@ -139,13 +138,6 @@ Function Wait-RSJob {
         }
     }
     End {
-        $WhereList = New-Object System.Collections.ArrayList
-        if ($PSBoundParameters['State']) {
-            [void]$WhereList.Add("`$_.State -match `"$($State -join '|')`"")
-        }
-        if ($PSBoundParameters.ContainsKey('HasMoreData')) {
-            [void]$WhereList.Add("`$_.HasMoreData -eq `$$HasMoreData")
-        }
         # IF faster than any scriptblocks
         if ($PSCmdlet.ParameterSetName -ne 'Job') {
             if ($PSCmdlet.ParameterSetName -eq 'All') {
@@ -161,14 +153,14 @@ Function Wait-RSJob {
         }
         if ($WaitJobs.Count -and $PSBoundParameters.ContainsKey('State')) {
             $States = '^' + $State -join '$|^' + '$'
-            $WaitJobs = foreach ($job in $WaitJobs) {
+            [array]$WaitJobs = foreach ($job in $WaitJobs) {
                 if ($job.State -match $States) {
                     $job
                 }
             }
         }
         if ($WaitJobs.Count -and $PSBoundParameters.ContainsKey('HasMoreData')) {
-            $WaitJobs = foreach ($job in $WaitJobs) {
+            [array]$WaitJobs = foreach ($job in $WaitJobs) {
                 if ($job.HasMoreData -eq $HasMoreData) {
                     $job
                 }

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -61,10 +61,10 @@ Function Wait-RSJob {
         [Alias('InputObject')]
         [RSJob[]]$Job,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Name')]
+        ParameterSetName='Name', Position=0)]
         [string[]]$Name,
         [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
-        ParameterSetName='Id')]
+        ParameterSetName='Id', Position=0)]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,
         ParameterSetName='InstanceID')]

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -60,10 +60,10 @@ Function Wait-RSJob {
         ParameterSetName='Job', Position=0)]
         [Alias('InputObject')]
         [RSJob[]]$Job,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Name')]
         [string[]]$Name,
-        [parameter(ValueFromPipelineByPropertyName=$True,
+        [parameter(ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True,
         ParameterSetName='Id')]
         [int[]]$Id,
         [parameter(ValueFromPipelineByPropertyName=$True,

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -141,7 +141,10 @@ Function Wait-RSJob {
         # IF faster than any scriptblocks
         if ($PSCmdlet.ParameterSetName -ne 'Job') {
             if ($PSCmdlet.ParameterSetName -eq 'All') {
-                $WaitJobs = $PoshRS_Jobs
+                if ($PSBoundParameters.ContainsKey('State') -or
+                    $PSBoundParameters.ContainsKey('HasMoreData')) {
+                    $WaitJobs = $PoshRS_Jobs
+                }
             }
             else {
                 foreach ($job in $PoshRS_Jobs) {

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -87,53 +87,19 @@ Function Wait-RSJob {
         If ($PSBoundParameters['Debug']) {
             $DebugPreference = 'Continue'
         }        
-        Write-Verbose "ParameterSet: $($PSCmdlet.ParameterSetName)"
         $WaitJobs = New-Object System.Collections.ArrayList
         $Hash = @{}
-        $Property = $PSCmdlet.ParameterSetName
-        $IsPipeline = $true
-        #Take care of bound parameters
-        If ($PSBoundParameters['Name']) {
-            $IsPipeline = $false
-            foreach ($v in $Name) {
-                $Hash.Add($v,1)
-            }
-        }
-        If ($PSBoundParameters['Batch']) {
-            $IsPipeline = $false
-            foreach ($v in $Batch) {
-                $Hash.Add($v,1)
-            }
-        }
-        If ($PSBoundParameters['Id']) {
-            $IsPipeline = $false
-            foreach ($v in $Id) {
-                $Hash.Add($v,1)
-            }
-        }
-        If ($PSBoundParameters['InstanceId']) {
-            $IsPipeline = $false
-            foreach ($v in $InstanceId) {
-                $Hash.Add($v,1)
-            }
-        }
-        If ($PSBoundParameters['Job']){
-            $IsPipeline = $false
-            [void]$WaitJobs.AddRange($Job)
-        }
     }
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
-        if ($IsPipeline) {
-            $Property = $PSCmdlet.ParameterSetName
-            if ($PSCmdlet.ParameterSetName -eq 'Job') {
-                [void]$WaitJobs.AddRange($Job)
-            }
-            elseif ($PSCmdlet.ParameterSetName -ne 'All') {
-                Write-Verbose "Adding $($PSBoundParameters[$Property])"
-                foreach ($v in $PSBoundParameters[$Property]) {
-                    $Hash.Add($v,1)
-                }
+        $Property = $PSCmdlet.ParameterSetName
+        if ($PSCmdlet.ParameterSetName -eq 'Job') {
+            [void]$WaitJobs.AddRange($Job)
+        }
+        elseif ($PSCmdlet.ParameterSetName -ne 'All') {
+            Write-Verbose "Adding $($PSBoundParameters[$Property])"
+            foreach ($v in $PSBoundParameters[$Property]) {
+                $Hash.Add($v,1)
             }
         }
     }

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -92,7 +92,7 @@ Function Wait-RSJob {
     Process {
         Write-Debug "ParameterSet: $($PSCmdlet.ParameterSetName)"
         $Property = $PSCmdlet.ParameterSetName
-        if ($PSCmdlet.ParameterSetName -ne 'All') {
+        if ($PSCmdlet.ParameterSetName -ne 'All' -and $PSBoundParameters[$Property]) {
             Write-Verbose "Adding $($PSBoundParameters[$Property])"
             [void]$List.AddRange($PSBoundParameters[$Property])
         }

--- a/Tests/PoshRSJob.Tests.ps1
+++ b/Tests/PoshRSJob.Tests.ps1
@@ -26,14 +26,90 @@ function Test-RSJob([bool]$FullPiping=$true) {
     $ScriptBlock = { "{0}: {1}" -f $_, [DateTime]::Now; Start-Sleep -Seconds 5 }
     $params = @{ Batch='throttletest'; ScriptBlock=$ScriptBlock; Throttle=5 }
     if ($FullPiping) {
-        $jobs = 1..25 | Start-RSJob @params
+        $jobs = 1..15 | Start-RSJob @params
     }
     else {
-        $jobs = 1..25 | Foreach-Object { $_ | Start-RSJob @params }
+        $jobs = 1..15 | Foreach-Object { $_ | Start-RSJob @params }
     }
     $jobs | Wait-RSJob | Receive-RSJob
     $jobs | Remove-RSJob
 }
+
+$ParameterTestCases = @(
+    @{
+       Case = 'by job object'
+       Mode = 0
+       Param = { @{ Job = $TestJob } }
+    },
+    @{
+       Case = 'by job object positioned'
+       Mode = 1
+       Param = { $TestJob }
+    },
+    @{
+       Case = 'by job object from pipeline (name)'
+       Mode = 2
+       Param = { '' | Select @{n='Job'; e={$TestJob}} }
+    },
+    @{
+       Case = 'by job object from pipeline (value)'
+       Mode = 2
+       Param = { $TestJob }
+    },
+
+    @{
+       Case = 'by id'
+       Mode = 0
+       Param = { @{ Id = ($TestJob | Select-Object -Expand id) } }
+    },
+    @{
+       Case = 'by id positioned'
+       Mode = 1
+       Param = { $TestJob | Select-Object -Expand id }
+    },
+    @{
+       Case = 'by id from pipeline (name)'
+       Mode = 2
+       Param = { $TestJob | Select-Object id }
+    },
+    @{
+       Case = 'by id from pipeline (value)'
+       Mode = 2
+       Param = { $TestJob | Select-Object -Expand id }
+    },
+
+    @{
+       Case = 'by name'
+       Mode = 0
+       Param = { @{ Name = ($TestJob | Select-Object -Expand Name) } }
+    },
+    @{
+       Case = 'by name positioned'
+       Mode = 1
+       Param = { $TestJob | Select-Object -Expand Name }
+    },
+    @{
+       Case = 'by name from pipeline (name)'
+       Mode = 2
+       Param = { $TestJob | Select-Object Name }
+    },
+    @{
+       Case = 'by name from pipeline (value)'
+       Mode = 2
+       Param = { $TestJob | Select-Object -Expand Name }
+    },
+
+    @{
+       Case = 'by InstanceID'
+       Mode = 0
+       Param = { @{ InstanceID = ($TestJob | Select-Object -Expand InstanceID) } }
+    },
+    @{
+       Case = 'by InstanceID from pipeline (name)'
+       Mode = 2
+       Param = { $TestJob | Select-Object InstanceID }
+    }
+)
 
 Describe "PoshRSJob PS$($PSVersion)" {
     Context 'Strict mode' {
@@ -107,9 +183,66 @@ Describe "Start-RSJob PS$PSVersion" {
     }
 }
 
+Describe "Get-RSJob PS$PSVersion" {
+    Context 'Strict mode' {
+        Set-StrictMode -Version latest
+        It 'should return all job details' {
+            $Output = @( Get-RSJob @Verbose )
+            $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
+
+            $Output.count | Should be 10
+            $Props -contains "Id" | Should be $True
+            $Props -contains "State" | Should be $True
+            $Props -contains "HasMoreData" | Should be $True
+        }
+
+        It 'should return job by state' {
+            1..10 | Start-RSJob { Start-Sleep -Seconds 5; $_ } -Throttle 5
+            $Jobs = @(Get-RSJob -State NotStarted)
+            $Jobs.Count | Should Be 5
+        }
+
+        It 'should return job details <Case>' -TestCases $ParameterTestCases {
+            param(
+                $Case,
+                $Mode,
+                $Param
+            )
+
+            $TestJob = Start-RSJob -Name "TestJob $Case" -ScriptBlock { $text=$using:Case; "Working on $text" }
+
+            switch ($Mode) {
+                0 {
+                    $Parameters = & $Param
+                    $Output = @( Get-RSJob @Verbose @Parameters )
+                }
+                1 {
+                    $Parameters = & $Param
+                    $Output = @( Get-RSJob @Verbose $Parameters )
+                }
+                2 {
+                    $Parameters = & $Param
+                    $Output = @( $Parameters | Get-RSJob @Verbose )
+                }
+                default {
+                    # Fail test on invalid mode
+                    'Invalid mode !' | Should be 'Invalid mode !!!'
+                }
+            }
+
+            $Output.Count | Should be 1
+			$Output[0] -is 'RSJob' | Should be $true
+			$Output[0].Name | Should be "TestJob $Case"
+        }
+    }
+}
+
 Describe "Stop-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
+        It 'should not stop a job' {
+            Stop-RSJob | Should BeNullOrEmpty
+        }
         It 'should stop a job' {
             $Job = 1 | Start-RSJob -ScriptBlock {
                 While ($True) {$Null}
@@ -118,108 +251,35 @@ Describe "Stop-RSJob PS$PSVersion" {
             Start-Sleep -Milliseconds 100
             $Job.State | Should be 'Stopped'
         }
-    }
-}
-
-Describe "Get-RSJob PS$PSVersion" {
-    Context 'Strict mode' {
-        Set-StrictMode -Version latest
-        It 'should return all job details' {
-            $Output = @( Get-RSJob @Verbose )
-            $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-
-            $Output.count | Should be 11
-            $Props -contains "Id" | Should be $True
-            $Props -contains "State" | Should be $True
-            $Props -contains "HasMoreData" | Should be $True
-        }
-        It 'should return job details based on ID' {
-            $Output = @( Get-RSJob @Verbose -Id 1 )
-            $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-
-            $Output.count | Should be 1
-            $Props -contains "Id" | Should be $True
-            $Props -contains "State" | Should be $True
-            $Props -contains "HasMoreData" | Should be $True
-        }
-        It 'should return job details based on Name' {
-            $Output = @( Get-RSJob @Verbose -Name Job2 )
-            $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-
-            $Output.count | Should be 1
-            $Props -contains "Id" | Should be $True
-            $Props -contains "State" | Should be $True
-            $Props -contains "HasMoreData" | Should be $True
-        }
-    }
-}
-
-Describe "Remove-RSJob PS$PSVersion" {
-    Context 'Strict mode' {
-        Set-StrictMode -Version latest
-        It 'should remove jobs' {
-            Get-RSJob @Verbose | Remove-RSJob @Verbose
-            $Output = @( Get-RSJob @Verbose )
-
-            $Output.count | Should be 0
-        }
-        It 'should only remove specified jobs by ID' {
-             $TestJobs = @( 1..5 | Start-RSJob @Verbose -ScriptBlock { "" } )
-             Start-Sleep -Seconds 2
-             $ThisJobId = $TestJobs[0].ID
-             $AllIDs = @( $TestJobs | Select-Object -ExpandProperty Id )
-             Remove-RSJob @Verbose -Id $ThisJobId
-             $RemainingIDs = @( Get-RSJob @Verbose -Id $AllIDs | Select-Object -ExpandProperty Id )
-             #We only removed one
-             $RemainingIDs.count -eq ($AllIDs.count - 1) | Should Be $True
-             #We removed the right ID
-             $RemainingIDs -notcontains $ThisJobId | Should Be $True
-        }
-        It 'should only remove specified jobs by Name' {
-             $TestJobs = @( 1..5 | Start-RSJob @Verbose -ScriptBlock { "" } )
-             Start-Sleep -Seconds 2
-             $ThisJobName = $TestJobs[0].Name
-             $AllNames = @( $TestJobs | Select-Object -ExpandProperty Name )
-             Remove-RSJob @Verbose -Name $ThisJobName
-             $RemainingNames = @( Get-RSJob @Verbose -Name $AllNames | Select-Object -ExpandProperty Name )
-             #We only removed one
-             $RemainingNames.count -eq ($AllNames.count - 1) | Should Be $True
-             #We removed the right ID
-             $RemainingNames -notcontains $ThisJobName | Should Be $True
-        }
-        It 'should only remove specified jobs by InputObject' {
-             $TestJobs = @( 1..5 | Start-RSJob @Verbose -ScriptBlock { "" })
-             Start-Sleep -Seconds 2
-             $ThisJob = $TestJobs[0]
-             $ThisJob | Remove-RSJob @Verbose
-             $RemainingNames = @( $TestJobs | Get-RSJob @Verbose | Select-Object -ExpandProperty Name)
-             #We only removed one
-             $RemainingNames.count -eq ($TestJobs.count - 1) | Should Be $True
-             #We removed the right ID
-             $RemainingNames -notcontains $ThisJob.Name | Should Be $True
-        }
-    }
-}
-
-Describe "Receive-RSJob PS$PSVersion" {
-    Context 'Strict mode' {
-        Set-StrictMode -Version latest
-        It 'should retrieve job data' {
-            $TestJob = 0 | Start-RSJob @Verbose -ScriptBlock {"Working on $_"}
-            Start-Sleep -Seconds 1
-
-            $Output = @( $TestJob | Receive-RSJob @Verbose )
-            $Output.Count | Should be 1
-            $Output[0] | Should be "Working on 0"
-
-        }
-        It 'should not remove the job' {
-            $TestJob = 0 | Start-RSJob @Verbose -ScriptBlock {""}
-            Start-Sleep -Seconds 1
-            $TestJob | Receive-RSJob @Verbose | Out-Null
-
-            $Output = @( $TestJob | Get-RSJob @Verbose )
-            $Output.Count | Should be 1
+        It 'should stop a job <Case>' -TestCases $ParameterTestCases {
+            param(
+                $Case,
+                $Mode,
+                $Param
+            )
+            $TestJob = 1 | Start-RSJob -ScriptBlock {
+                While ($True) {$Null}
+            }
+            switch ($Mode) {
+                0 {
+                    $Parameters = & $Param
+                    Stop-RSJob @Parameters
+                }
+                1 {
+                    $Parameters = & $Param
+                    Stop-RSJob $Parameters
+                }
+                2 {
+                    $Parameters = & $Param
+                    $Parameters | Stop-RSJob
+                }
+                default {
+                    # Fail test on invalid mode
+                    'Invalid mode !' | Should be 'Invalid mode !!!'
+                }
+            }
+            Start-Sleep -Milliseconds 100
+            $TestJob.State | Should be 'Stopped'
         }
     }
 }
@@ -227,71 +287,171 @@ Describe "Receive-RSJob PS$PSVersion" {
 Describe "Wait-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
-        It 'should wait for jobs' {
+
+        It 'should not wait a job' {
+            Wait-RSJob | Should BeNullOrEmpty
+        }
+
+        It 'should wait for jobs <Case>' -TestCases $ParameterTestCases {
+            param(
+                $Case,
+                $Mode,
+                $Param
+            )
             $StartDate = Get-Date
             $TestJob = 0 | Start-RSJob @Verbose -ScriptBlock {
-                Start-Sleep -seconds 5
+                Start-Sleep -seconds 3
                 Get-Date
             }
-            $TestJob | Wait-RSJob # Omitted verbose to avoid clutter
+            switch ($Mode) {
+                0 {
+                    $Parameters = & $Param
+                    Wait-RSJob @Parameters # Omitted verbose to avoid clutter
+                }
+                1 {
+                    $Parameters = & $Param
+                    Wait-RSJob $Parameters # Omitted verbose to avoid clutter
+                }
+                2 {
+                    $Parameters = & $Param
+                    $Parameters | Wait-RSJob # Omitted verbose to avoid clutter
+                }
+                default {
+                    # Fail test on invalid mode
+                    'Invalid mode !' | Should be 'Invalid mode !!!'
+                }
+            }
             $EndDate = Get-Date
-            ( $EndDate - $StartDate ).TotalSeconds -gt 5 | Should be $True
-        }
-        It 'should wait for jobs by Name' {
-            $TestJob = 1..3 | Foreach {
-                Start-RSJob -Name "NameTest1$_" @Verbose -ScriptBlock {
-                Start-Sleep -seconds 5
-                Get-Date
-            } }
-            [array]$Result = Wait-RSJob -Name ($TestJob | Select -Expand Name) # Omitted verbose to avoid clutter
-            $Result.Count -eq $TestJob.Count | Should be $True
-        }
-        It 'should wait for jobs by Name from pipeline' {
-            $TestJob = 1..3 | Foreach {
-                Start-RSJob -Name "NameTest2$_" @Verbose -ScriptBlock {
-                Start-Sleep -seconds 5
-                Get-Date
-            } }
-            [array]$Result = $TestJob | Select Name | Wait-RSJob # Omitted verbose to avoid clutter
-            $Result.Count -eq $TestJob.Count | Should be $True
-        }
-        It 'should wait for jobs by id' {
-            $TestJob = 1..3 | Foreach {
-                Start-RSJob @Verbose -ScriptBlock {
-                Start-Sleep -seconds 5
-                Get-Date
-            } }
-            [array]$Result = Wait-RSJob -Id ($TestJob | Select -Expand Id) # Omitted verbose to avoid clutter
-            $Result.Count -eq $TestJob.Count | Should be $True
-        }
-        It 'should wait for jobs by InstanceId' {
-            $TestJob = 1..3 | Foreach {
-                Start-RSJob @Verbose -ScriptBlock {
-                Start-Sleep -seconds 5
-                Get-Date
-            } }
-            [array]$Result = Wait-RSJob -InstanceId ($TestJob | Select -Expand InstanceId) # Omitted verbose to avoid clutter
-            $Result.Count -eq $TestJob.Count | Should be $True
+            ( $EndDate - $StartDate ).TotalSeconds -gt 3 | Should be $True
         }
     }
 }
 
+Describe "Receive-RSJob PS$PSVersion" {
+    Context 'Strict mode' {
+        Set-StrictMode -Version latest
+
+        It 'should not retrieve a job' {
+            Receive-RSJob | Should BeNullOrEmpty
+        }
+
+        It 'should retrieve job data <Case>' -TestCases $ParameterTestCases {
+            param(
+                $Case,
+                $Mode,
+                $Param
+            )
+            $TestJob = Get-RSJob -Name "TestJob $Case"
+
+            switch ($Mode) {
+                0 {
+                    $Parameters = & $Param
+                    $Output = @( Receive-RSJob @Verbose @Parameters )
+                }
+                1 {
+                    $Parameters = & $Param
+                    $Output = @( Receive-RSJob @Verbose $Parameters )
+                }
+                2 {
+                    $Parameters = & $Param
+                    $Output = @( $Parameters | Receive-RSJob @Verbose)
+                }
+                default {
+                    # Fail test on invalid mode
+                    'Invalid mode !' | Should be 'Invalid mode !!!'
+                }
+            }
+            $Output.Count | Should be 1
+            $Output[0] | Should be "Working on $Case"
+        }
+    }
+}
+
+Describe "Remove-RSJob PS$PSVersion" {
+    Context 'Strict mode' {
+        Set-StrictMode -Version latest
+
+        It 'should not remove a job' {
+            Remove-RSJob | Should BeNullOrEmpty
+        }
+
+        It 'should only remove specified jobs <Case>' -TestCases $ParameterTestCases {
+            param(
+                $Case,
+                $Mode,
+                $Param
+            )
+            $TestJobs = @(Get-RSJob | Where-Object { $_.Name -match "^TestJob " })
+            $TestJobs.Count -gt 0 | Should Be $True
+
+            $TestJob = $TestJobs | Where-Object { $_.Name -eq "TestJob $Case" }
+			$TestJob -is 'RSJob' | Should be $true
+
+            $AllIDs = @( $TestJobs | Select-Object -ExpandProperty Id )
+
+            switch ($Mode) {
+                0 {
+                    $Parameters = & $Param
+                    Remove-RSJob @Verbose @Parameters
+                }
+                1 {
+                    $Parameters = & $Param
+                    Remove-RSJob @Verbose $Parameters
+                }
+                2 {
+                    $Parameters = & $Param
+                    $Parameters | Remove-RSJob @Verbose
+                }
+                default {
+                    # Fail test on invalid mode
+                    'Invalid mode !' | Should be 'Invalid mode !!!'
+                }
+            }
+
+            $RemainingIDs = @( Get-RSJob @Verbose -Id $AllIDs | Select-Object -ExpandProperty Id )
+            #We only removed one
+            $RemainingIDs.Count -eq ($AllIDs.Count - 1) | Should Be $True
+            #We removed the right ID
+            $RemainingIDs -notcontains $TestJob.Id | Should Be $True
+        }
+
+        It 'should not remove job' {
+            $TestJob = 1 | Start-RSJob -Name 'ByForce' -ScriptBlock {
+                While ($True) {$Null}
+            }
+			$TestJob -is 'RSJob' | Should be $true
+            { Remove-RSJob $TestJob -ErrorAction Stop } | Should Throw
+        }
+        It 'should remove job by force' {
+            $TestJob = Get-RSJob -Name 'ByForce'
+			$TestJob -is 'RSJob' | Should be $true
+            { Remove-RSJob $TestJob -Force } | Should Not Throw
+            $TestJob = Get-RSJob -Name 'ByForce'
+			$TestJob | Should BeNullOrEmpty
+        }
+        It 'should remove all jobs' {
+            Get-RSJob @Verbose | Remove-RSJob @Verbose
+            $Output = @( Get-RSJob @Verbose )
+
+            $Output.Count | Should be 0
+        }
+    }
+}
 
 Describe "Test RSJob Throttling" {
     It "Full Pipe input" {
         $StartDate = Get-Date
         Test-RSJob $true
             $EndDate = Get-Date
-        ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
+        ( $EndDate - $StartDate ).TotalSeconds -gt 15 | Should be $True
     }
     It "OneByOne Pipe input" {
         $StartDate = Get-Date
         Test-RSJob $false
             $EndDate = Get-Date
-            ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
+            ( $EndDate - $StartDate ).TotalSeconds -gt 15 | Should be $True
     }
 }
-
 
 Describe "Module OnRemove Actions PS$PSVersion" {
     Context 'Strict mode' {

--- a/Tests/PoshRSJob.Tests.ps1
+++ b/Tests/PoshRSJob.Tests.ps1
@@ -59,7 +59,7 @@ Describe "PoshRSJob PS$($PSVersion)" {
             $Commands -contains "wsj"    | Should be $True
         }
         It 'should initialize necessary variables' {
-            $PSCmdlet.SessionState.PSVariable.Get('PoshRS_runspacepools').Name | Should Be 'PoshRS_RunspacePools'
+            $PSCmdlet.SessionState.PSVariable.Get('PoshRS_RunspacePools').Name | Should Be 'PoshRS_RunspacePools'
             $PSCmdlet.SessionState.PSVariable.Get('PoshRS_RunspacePoolCleanup').Name | Should Be 'PoshRS_RunspacePoolCleanup'
             $PSCmdlet.SessionState.PSVariable.Get('PoshRS_JobCleanup').Name | Should Be 'PoshRS_JobCleanup'
             $PSCmdlet.SessionState.PSVariable.Get('PoshRS_JobID').Name | Should Be 'PoshRS_JobID'
@@ -67,7 +67,7 @@ Describe "PoshRSJob PS$($PSVersion)" {
         }
     }
 }
- 
+
 Describe "Start-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
@@ -77,9 +77,9 @@ Describe "Start-RSJob PS$PSVersion" {
             $SecondJob = Start-RSJob {$Null}
             $NextID = $SecondJob.Id
             $NextID - $InitialID | Should Be 1
- 
+
         }
-        It 'should return initial job details' {           
+        It 'should return initial job details' {
             $Output1 = @( 1 | Start-RSJob @Verbose -ScriptBlock {
                 Param($Object)
                 $Object
@@ -90,7 +90,7 @@ Describe "Start-RSJob PS$PSVersion" {
             } )
             $Output1.Count | Should be 1
             $Output5.Count | Should be 5
-        }        
+        }
         It 'should support $using syntax' {
             $Test = "5"
             $Output1 = 1 | Start-RSJob @Verbose -ScriptBlock {
@@ -103,7 +103,7 @@ Describe "Start-RSJob PS$PSVersion" {
                 $_
             } ) | Wait-RSJob | Receive-RSJob
             $Output1 | Should Be 1
-        }             
+        }
     }
 }
 
@@ -120,23 +120,23 @@ Describe "Stop-RSJob PS$PSVersion" {
         }
     }
 }
- 
+
 Describe "Get-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
         It 'should return all job details' {
             $Output = @( Get-RSJob @Verbose )
             $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-           
+
             $Output.count | Should be 11
             $Props -contains "Id" | Should be $True
             $Props -contains "State" | Should be $True
             $Props -contains "HasMoreData" | Should be $True
-        }       
+        }
         It 'should return job details based on ID' {
             $Output = @( Get-RSJob @Verbose -Id 1 )
             $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-           
+
             $Output.count | Should be 1
             $Props -contains "Id" | Should be $True
             $Props -contains "State" | Should be $True
@@ -145,7 +145,7 @@ Describe "Get-RSJob PS$PSVersion" {
         It 'should return job details based on Name' {
             $Output = @( Get-RSJob @Verbose -Name Job2 )
             $Props = $Output[0].PSObject.Properties | Select-Object -ExpandProperty Name
-           
+
             $Output.count | Should be 1
             $Props -contains "Id" | Should be $True
             $Props -contains "State" | Should be $True
@@ -153,14 +153,14 @@ Describe "Get-RSJob PS$PSVersion" {
         }
     }
 }
- 
+
 Describe "Remove-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
         It 'should remove jobs' {
             Get-RSJob @Verbose | Remove-RSJob @Verbose
             $Output = @( Get-RSJob @Verbose )
-           
+
             $Output.count | Should be 0
         }
         It 'should only remove specified jobs by ID' {
@@ -185,9 +185,9 @@ Describe "Remove-RSJob PS$PSVersion" {
              #We only removed one
              $RemainingNames.count -eq ($AllNames.count - 1) | Should Be $True
              #We removed the right ID
-             $RemainingNames -notcontains $ThisJobName | Should Be $True           
+             $RemainingNames -notcontains $ThisJobName | Should Be $True
         }
-        It 'should only remove specified jobs by InputObject' {            
+        It 'should only remove specified jobs by InputObject' {
              $TestJobs = @( 1..5 | Start-RSJob @Verbose -ScriptBlock { "" })
              Start-Sleep -Seconds 2
              $ThisJob = $TestJobs[0]
@@ -196,34 +196,34 @@ Describe "Remove-RSJob PS$PSVersion" {
              #We only removed one
              $RemainingNames.count -eq ($TestJobs.count - 1) | Should Be $True
              #We removed the right ID
-             $RemainingNames -notcontains $ThisJob.Name | Should Be $True             
+             $RemainingNames -notcontains $ThisJob.Name | Should Be $True
         }
     }
 }
- 
+
 Describe "Receive-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
         It 'should retrieve job data' {
             $TestJob = 0 | Start-RSJob @Verbose -ScriptBlock {"Working on $_"}
             Start-Sleep -Seconds 1
-           
+
             $Output = @( $TestJob | Receive-RSJob @Verbose )
             $Output.Count | Should be 1
             $Output[0] | Should be "Working on 0"
-           
+
         }
         It 'should not remove the job' {
             $TestJob = 0 | Start-RSJob @Verbose -ScriptBlock {""}
             Start-Sleep -Seconds 1
             $TestJob | Receive-RSJob @Verbose | Out-Null
-           
+
             $Output = @( $TestJob | Get-RSJob @Verbose )
             $Output.Count | Should be 1
         }
     }
 }
- 
+
 Describe "Wait-RSJob PS$PSVersion" {
     Context 'Strict mode' {
         Set-StrictMode -Version latest
@@ -234,7 +234,7 @@ Describe "Wait-RSJob PS$PSVersion" {
                 Get-Date
             }
             $TestJob | Wait-RSJob # Omitted verbose to avoid clutter
-            $EndDate = Get-Date           
+            $EndDate = Get-Date
             ( $EndDate - $StartDate ).TotalSeconds -gt 5 | Should be $True
         }
         It 'should wait for jobs by Name' {
@@ -281,13 +281,13 @@ Describe "Test RSJob Throttling" {
     It "Full Pipe input" {
         $StartDate = Get-Date
         Test-RSJob $true
-            $EndDate = Get-Date           
+            $EndDate = Get-Date
         ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
     }
     It "OneByOne Pipe input" {
         $StartDate = Get-Date
         Test-RSJob $false
-            $EndDate = Get-Date           
+            $EndDate = Get-Date
             ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
     }
 }

--- a/Tests/PoshRSJob.Tests.ps1
+++ b/Tests/PoshRSJob.Tests.ps1
@@ -237,23 +237,59 @@ Describe "Wait-RSJob PS$PSVersion" {
             $EndDate = Get-Date           
             ( $EndDate - $StartDate ).TotalSeconds -gt 5 | Should be $True
         }
+        It 'should wait for jobs by Name' {
+            $TestJob = 1..3 | Foreach {
+                Start-RSJob -Name "NameTest1$_" @Verbose -ScriptBlock {
+                Start-Sleep -seconds 5
+                Get-Date
+            } }
+            [array]$Result = Wait-RSJob -Name ($TestJob | Select -Expand Name) # Omitted verbose to avoid clutter
+            $Result.Count -eq $TestJob.Count | Should be $True
+        }
+        It 'should wait for jobs by Name from pipeline' {
+            $TestJob = 1..3 | Foreach {
+                Start-RSJob -Name "NameTest2$_" @Verbose -ScriptBlock {
+                Start-Sleep -seconds 5
+                Get-Date
+            } }
+            [array]$Result = $TestJob | Select Name | Wait-RSJob # Omitted verbose to avoid clutter
+            $Result.Count -eq $TestJob.Count | Should be $True
+        }
+        It 'should wait for jobs by id' {
+            $TestJob = 1..3 | Foreach {
+                Start-RSJob @Verbose -ScriptBlock {
+                Start-Sleep -seconds 5
+                Get-Date
+            } }
+            [array]$Result = Wait-RSJob -Id ($TestJob | Select -Expand Id) # Omitted verbose to avoid clutter
+            $Result.Count -eq $TestJob.Count | Should be $True
+        }
+        It 'should wait for jobs by InstanceId' {
+            $TestJob = 1..3 | Foreach {
+                Start-RSJob @Verbose -ScriptBlock {
+                Start-Sleep -seconds 5
+                Get-Date
+            } }
+            [array]$Result = Wait-RSJob -InstanceId ($TestJob | Select -Expand InstanceId) # Omitted verbose to avoid clutter
+            $Result.Count -eq $TestJob.Count | Should be $True
+        }
     }
 }
 
 
 Describe "Test RSJob Throttling" {
-	It "Full Pipe input" {
-		$StartDate = Get-Date
-		Test-RSJob $true
-        	$EndDate = Get-Date           
-		( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
-	}
-	It "OneByOne Pipe input" {
-		$StartDate = Get-Date
-		Test-RSJob $false
-        	$EndDate = Get-Date           
-        	( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
-	}
+    It "Full Pipe input" {
+        $StartDate = Get-Date
+        Test-RSJob $true
+            $EndDate = Get-Date           
+        ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
+    }
+    It "OneByOne Pipe input" {
+        $StartDate = Get-Date
+        Test-RSJob $false
+            $EndDate = Get-Date           
+            ( $EndDate - $StartDate ).TotalSeconds -gt 25 | Should be $True
+    }
 }
 
 
@@ -262,11 +298,11 @@ Describe "Module OnRemove Actions PS$PSVersion" {
         Get-RSJob | Remove-RSJob
         Remove-Module -Name PoshRSJob -ErrorAction SilentlyContinue
         It 'should remove all variables' {
-            {Get-Variable Jobs -ErrorAction Stop} | Should Throw
-            {Get-Variable JobCleanup -ErrorAction Stop} | Should Throw
-            {Get-Variable JobID -ErrorAction Stop} | Should Throw
-            {Get-Variable RunspacePoolCleanup -ErrorAction Stop} | Should Throw
-            {Get-Variable RunspacePools -ErrorAction Stop} | Should Throw
+            {Get-Variable PoshRS_Jobs -ErrorAction Stop} | Should Throw
+            {Get-Variable PoshRS_JobCleanup -ErrorAction Stop} | Should Throw
+            {Get-Variable PoshRS_JobID -ErrorAction Stop} | Should Throw
+            {Get-Variable PoshRS_RunspacePoolCleanup -ErrorAction Stop} | Should Throw
+            {Get-Variable PoshRS_RunspacePools -ErrorAction Stop} | Should Throw
         }
     }
 }


### PR DESCRIPTION
Fixes for #139, #140, #141.

Changes proposed in this pull request:
  Unified interfaces for all cmdlets except `Start-RSJob`
  Fixed `OnRemove` tests
  spacing cleanup

My testing ( mocked 50000 objects, search for 10-100 names) show that this code 1500 times faster!
(new  1 milliseconds vs old 1600ms)
when searched for 1000 names it run 10ms, old ~ 4500ms
on 500000 objects  and 100000 names it run about 500 ms, while old wait forever :)

Has been tested on (remove any that don't apply):
 - Powershell 2 and above
 - Windows 7 and above
