### PR TITLE
Added Current Host to Threads

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -413,7 +413,7 @@ Function Start-RSJob {
                 Else {
                     Write-Verbose "Creating new runspacepool <$Batch>"
                     $RunspacePoolID = $Batch
-                    $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
+                    $RunspacePool = [runspacefactory]::CreateRunspacePool(1, $Throttle, $InitialSessionState, $Host)
                     If ($RunspacePool.psobject.Properties["ApartmentState"]) {
                         #ApartmentState doesn't exist in Nano Server
                         $RunspacePool.ApartmentState = 'STA'


### PR DESCRIPTION
This allows passing open connections through to the threads. For example: without this additional code running Get-AzureRMVM would require running Login-AzureRMAccount on each thread. With the addition of this code you only need to run Login-AzureRMAccount outside the scope of the Start-RSJob cmdlet one time and not in each thread.


Changes proposed in this pull request:
 - Adding $Host to creation of RunspacePool
 - 
 - 

How to test this code:
 - Create a connection to a service like Microsoft Azure or Exchange Online in host console/ISE
 - Run a command derived from that connection such as Get-AzureRMVM or Get-Mailbox
 - Instead of an error requiring a login the connection will pass through to the threads

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
