### PR TITLE
Revised param()/ArgumentList handling

### DIFF
--- a/PoshRSJob/Public/Get-RSJob.ps1
+++ b/PoshRSJob/Public/Get-RSJob.ps1
@@ -110,7 +110,7 @@ Function Get-RSJob {
         $Property = $PSCmdlet.ParameterSetName
 
         if ($PSCmdlet.ParameterSetName -eq 'Job') {
-            Write-Verbose "Adding Job $($PSBoundParameters[$Property])"
+            Write-Verbose "Adding Job $($PSBoundParameters[$Property].Id)"
             foreach ($v in $PSBoundParameters[$Property]) {
                 $Hash.Add($v.ID,1)
             }

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -336,15 +336,15 @@ Function Start-RSJob {
             $ArgumentCount++
         }
         # we add $_ into param() block when (ArgumentList+InputObject).Count > scriptBlock.Param().Count #or ForeachDetected
-        $InsertPSItemParam = ($ArgumentCount -gt $SBParamCount -and $List.Count) #-or $ForeachDetected
+        #$InsertPSItemParam = ($ArgumentCount -gt $SBParamCount -and $List.Count)
 
-        <# Current version behaviour variant
+        # Current version behaviour variant
         $ArgumentCount = $ArgumentList.Count
         # Without 'Ignore' fix
-        $InsertPSItemParam = ($SBParamCount -ne 1 -or (($SBParamCount -ne $ArgumentCount) -xor $List.Count))
+        #$InsertPSItemParam = ($SBParamCount -ne 1 -or (($SBParamCount -ne $ArgumentCount) -xor $List.Count))
         # With 'Ignore' fix
         $InsertPSItemParam = (($SBParamCount -ne 1 -or $SBParamCount -eq $ArgumentCount) -and $List.Count)
-        #>
+        #
 
         Write-Debug ("ArgumentCount: $ArgumentCount | List.Count: $($List.Count) | SBParamCount: $SBParamCount | InsertPSItemParam: $InsertPSItemParam")
         #region Convert ScriptBlock for $Using:

--- a/PoshRSJob/Public/Wait-RSJob.ps1
+++ b/PoshRSJob/Public/Wait-RSJob.ps1
@@ -138,5 +138,8 @@ Function Wait-RSJob {
                 break
             }
         }
+        If ($ShowProgress) {
+            Write-Progress -Activity "RSJobs Tracker" -Completed
+        }
     }
 }


### PR DESCRIPTION
Fixes #148 (?), #145, #144, #134

Changes proposed in this pull request:
 - completely redesigned `param()` vs `-ArgumentList` handling
 - merged two branches of code for with/without pipeline cases

How to test this code:
 - testing script for parameter handling comparison
 - https://gist.github.com/MVKozlov/e40e8b5b8d29361cc8eff9d3408ea2b0

Has been tested on (remove any that don't apply):
 - Powershell 2 and above
 - Windows 7 and above
