### PR TITLE
Save and restore $env:PSModulePath until we find why it's being clobbered on PS Core

### DIFF
--- a/PoshRSJob/PoshRSJob.psd1
+++ b/PoshRSJob/PoshRSJob.psd1
@@ -1,7 +1,7 @@
 ﻿
 #
 # PoshRSJob
-# Version 1.7.4.3
+# Version 1.7.4.4
 #
 # Boe Prox (c) 2014
 # http://learn-powershell.net
@@ -14,7 +14,7 @@
 ModuleToProcess = 'PoshRSJob.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7.4.3'
+ModuleVersion = '1.7.4.4'
 
 # ID used to uniquely identify this module
 GUID = '9b17fb0f-e939-4a5c-b194-3f2247452972'

--- a/PoshRSJob/PoshRSJob.psm1
+++ b/PoshRSJob/PoshRSJob.psm1
@@ -115,6 +115,7 @@ New-Variable PoshRS_RunspacePoolCleanup -Value ([hashtable]::Synchronized(@{})) 
 Write-Verbose "Creating routine to monitor RS jobs"
 $PoshRS_jobCleanup.Flag=$True
 $PoshRS_jobCleanup.Host = $Host
+$PSModulePath = $env:PSModulePath
 $PoshRS_jobCleanup.Runspace =[runspacefactory]::CreateRunspace()
 $PoshRS_jobCleanup.Runspace.Open()
 $PoshRS_jobCleanup.Runspace.SessionStateProxy.SetVariable("PoshRS_jobCleanup",$PoshRS_jobCleanup)
@@ -320,3 +321,5 @@ $ExportModule = @{
 }
 Export-ModuleMember @ExportModule
 #endregion Export Module Members
+
+$env:PSModulePath = $PSModulePath

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -511,6 +511,7 @@ Function Start-RSJob {
             Else {
                 Write-Verbose "Creating new runspacepool <$Batch>"
                 $RunspacePoolID = $Batch
+                $PSModulePath = $env:PSModulePath
                 $RunspacePool = [runspacefactory]::CreateRunspacePool($InitialSessionState)
                 If ($RunspacePool.psobject.Properties["ApartmentState"]) {
                     #ApartmentState doesn't exist in Nano Server
@@ -530,6 +531,7 @@ Function Start-RSJob {
 
                 #[System.Threading.Monitor]::Enter($PoshRS_RunspacePools.syncroot) #Temp add
                 [void]$PoshRS_RunspacePools.Add($RSPObject)
+                $env:PSModulePath = $PSModulePath
             }
         }
         finally {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PoshRSJob 1.7.4.3
+PoshRSJob 1.7.4.4
 
 [![Build status](https://ci.appveyor.com/api/projects/status/svrd4ho4otugki24?svg=true)](https://ci.appveyor.com/project/proxb/poshrsjob) [![Join the chat at https://gitter.im/proxb/PoshRSJob](https://badges.gitter.im/proxb/PoshRSJob.svg)](https://gitter.im/proxb/PoshRSJob?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -11,8 +11,8 @@ Provides an alternative to PSjobs with greater performance and less overhead to 
 Install-Module -Name PoshRSJob
 ```
 
-#### Download the latest release (1.7.4.3)
-https://github.com/proxb/PoshRSJob/releases/download/1.7.4.3/PoshRSJob.zip
+#### Download the latest release (1.7.4.4)
+https://github.com/proxb/PoshRSJob/releases/download/1.7.4.4/PoshRSJob.zip
 
 
 More information and examples here: http://learn-powershell.net/2015/04/19/latest-updates-to-poshrsjob/

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,9 @@
 ---------
+|1.7.4.4|
+---------
+* #175 Save and restore $env:PSModulePath until we find why it's being clobbered on PS Core
+
+---------
 |1.7.4.3|
 ---------
 * #48 Moved garbage collection in runspacepool cleanup


### PR DESCRIPTION
Fixes #175 .

Changes proposed in this pull request:
 - Save and restore $env:PSModulePath around the critical block

How to test this code:
pwsh
Add-WindowsPSModulePath
Import-Module PoshRSJob
Import-Module PoshRSJob

(I don't think it's possible to reproduce this on AppVeyor)

Has been tested on (remove any that don't apply):
 - Powershell 3 and above
 - Windows 7 and above