### PR TITLE
Add ImportPSModulesFromPath support

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -244,7 +244,7 @@ Function Start-RSJob {
             Write-Verbose "Resolving path of modules to import: $ModulesFromPathToImport"
             Try {
                 # Handle potential relative name and verify existence
-                $ModulePath = Resolve-Path -Path $ModulesFromPathToImport;
+                $ModulePath = Resolve-Path -Path $ModulesFromPathToImport -ErrorAction 'Stop';
                 Write-Verbose "Found full name for path of modules to import: $ModulePath"
             }
             Catch {

--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -36,6 +36,11 @@ Function Start-RSJob {
         .PARAMETER ModulesToImport
             A collection of modules that will be imported into the background runspace job.
 
+        .PARAMETER ModulesFromPathToImport
+            This is the path containing modules that will be imported into the background runspace job. Must be a single
+            path (i.e. not a collection of paths) containing one or more modules organized in subdirectories. This is
+            available on PowerShell V3 and above.
+
         .PARAMETER PSSnapinsToImport
             A collection of PSSnapins that will be imported into the background runspace job.
 
@@ -180,6 +185,8 @@ Function Start-RSJob {
         [parameter()]
         [Alias('ModulesToLoad')]
         [string[]]$ModulesToImport,
+        [Alias('ModulesFromPathToLoad')]
+        [string]$ModulesFromPathToImport,
         [parameter()]
         [Alias('PSSnapinsToLoad')]
         [string[]]$PSSnapinsToImport,
@@ -225,6 +232,10 @@ Function Start-RSJob {
 
         If ($PSBoundParameters['ModulesToImport']) {
             [void]$InitialSessionState.ImportPSModule($ModulesToImport)
+        }
+
+        If ($PSBoundParameters['ModulesFromPathToImport']) {
+            [void]$InitialSessionState.ImportPSModulesFromPath($ModulesFromPathToImport)
         }
 
         If ($PSBoundParameters['PSSnapinsToImport']) {


### PR DESCRIPTION
Add `Start-RSJob` parameter `ModulesFromPathToImport` that accepts a single path, from which module(s) will be imported into background runspace jobs. Modules in this path are not required to be listed by name, and the path does not have to exist in `$env:PSModulePath`. Fixes #177.

**Changes proposed in this pull request:**
 - Import module(s) into runspace job from a path specified by `Start-RSJob` parameter `-ModulesFromPathToImport`

**How to test this code:**
The snippet below allows manual verification of `Get-Module` output when either a full or relative module path name is passed. I'm relatively new to Pester, but would like to learn if someone has suggestions on how to setup the automated test cases.

```PowerShell
# assuming PoshRSJob is in $env:PSModulePath or imported, setup a sample custom module path.
# get both a full and relative path name for testing
$ModulePath = New-Item -Path ([Guid]::NewGuid().ToString()) -ItemType Directory
$RelativeModulePath = Resolve-Path -Path $ModulePath -Relative

# export sample modules for import in runspace
svn export https://github.com/psake/psake/tags/v4.7.0/src $ModulePath\psake | Out-Null;
svn export https://github.com/ramblingcookiemonster/PSDeploy/trunk/PSDeploy $ModulePath\PSDeploy | Out-Null;

# start single runspace job, passing full name of module path.
# Get-Module output in the runspace should show imported psake and PSDeploy modules.
"Modules from full path" | Start-RSJob -Name { $_ } -ModulesFromPathToImport $ModulePath -ScriptBlock {
    Get-Module;
} | Wait-RSJob | Receive-RSJob;

# do it again, this time with a relative module path
"Modules from relative path" | Start-RSJob -Name { $_ } -ModulesFromPathToImport $RelativeModulePath -Verbose -ScriptBlock {
    Get-Module;
} | Wait-RSJob | Receive-RSJob;

# cleanup
Remove-Item -Recurse -Force $ModulePath;
Remove-Variable -Name @("ModulePath", "RelativeModulePath");
```

**Has been tested on (remove any that don't apply):**
 - PowerShell 4.0
 - Windows 7 and 8.1
