### PR TITLE
Update Start-RSJob.ps1

### DIFF
--- a/PoshRSJob/Public/Start-RSJob.ps1
+++ b/PoshRSJob/Public/Start-RSJob.ps1
@@ -570,7 +570,13 @@ Function Start-RSJob {
 #            }
 #            else {
                 ForEach ($Argument in $ArgumentList) {
-                    Write-Verbose "Adding Argument: $($Argument) <$($Argument.GetType().Fullname)>"
+                    if ($null -eq $Argument) {
+                        Write-Verbose "Adding Argument: $($Argument) <NULL>"
+                    }
+                    else {
+                        Write-Verbose "Adding Argument: $($Argument) <$($Argument.GetType().Fullname)>"
+                    }
+
                     [void]$PowerShell.AddArgument($Argument)
                 }
 #            }


### PR DESCRIPTION
Check if argument is not null before checking its type

Fixes #189 .

Changes proposed in this pull request:
 - Check if argument is not null before showing its type

How to test this code:
```Powershell
Start-RSJob -ArgumentList 'x',$null -ScriptBlock {
    param(
        [string]$FirstInput,
        $DataInput
    )   
}
```
This should not show an error 

Has been tested on (remove any that don't apply):
 - Powershell 5
 - Windows 10
