### PR TITLE
Very minor formatting changes

### DIFF
--- a/PoshRSJob/PoshRSJob.psd1
+++ b/PoshRSJob/PoshRSJob.psd1
@@ -1,4 +1,4 @@
-﻿
+
 #
 # PoshRSJob
 # Version 1.7.4.4
@@ -14,7 +14,7 @@
 ModuleToProcess = 'PoshRSJob.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7.4.4'
+ModuleVersion = '1.7.4.5'
 
 # ID used to uniquely identify this module
 GUID = '9b17fb0f-e939-4a5c-b194-3f2247452972'
@@ -93,29 +93,29 @@ FileList = 'PoshRSJob.psd1', 'PoshRSJob.psm1', 'en-US\about_PoshRSJob.help.txt',
 # Private data to pass to the module specified in ModuleToProcess
 PrivateData = @{
     PSData = @{
-			# The primary categorization of this module (from the TechNet Gallery tech tree).
-			Category = "Multithreading"
+            # The primary categorization of this module (from the TechNet Gallery tech tree).
+            Category = "Multithreading"
 
-			# Keyword tags to help users find this module via navigations and search.
-			Tags = @('PoshRSJob', 'Runspace','RunspacePool', 'Linux', 'PowerShellCore', 'RSJob')
+            # Keyword tags to help users find this module via navigations and search.
+            Tags = @('PoshRSJob', 'Runspace','RunspacePool', 'Linux', 'PowerShellCore', 'RSJob')
 
-			# The web address of an icon which can be used in galleries to represent this module
-			#IconUri = ''
+            # The web address of an icon which can be used in galleries to represent this module
+            #IconUri = ''
 
-			# The web address of this module's project or support homepage.
-			ProjectUri = "https://github.com/proxb/PoshRSJob"
+            # The web address of this module's project or support homepage.
+            ProjectUri = "https://github.com/proxb/PoshRSJob"
 
-			# The web address of this module's license. Points to a page that's embeddable and linkable.
-			LicenseUri = "https://opensource.org/licenses/MIT"
+            # The web address of this module's license. Points to a page that's embeddable and linkable.
+            LicenseUri = "https://opensource.org/licenses/MIT"
 
-			# Release notes for this particular version of the module
-			# ReleaseNotes = False
+            # Release notes for this particular version of the module
+            # ReleaseNotes = False
 
-			# If true, the LicenseUrl points to an end-user license (not just a source license) which requires the user agreement before use.
-			RequireLicenseAcceptance = "False"
+            # If true, the LicenseUrl points to an end-user license (not just a source license) which requires the user agreement before use.
+            RequireLicenseAcceptance = "False"
 
-			# Indicates this is a pre-release/testing version of the module.
-			IsPrerelease = 'False'
-		}
+            # Indicates this is a pre-release/testing version of the module.
+            IsPrerelease = 'False'
+        }
     }
 }

--- a/PoshRSJob/Private/ConvertScript.ps1
+++ b/PoshRSJob/Private/ConvertScript.ps1
@@ -1,4 +1,4 @@
-﻿Function ConvertScript {
+Function ConvertScript {
     Param (
         [scriptblock]$ScriptBlock,
         [bool]$HasParam,

--- a/PoshRSJob/Private/ConvertScriptBlockV2.ps1
+++ b/PoshRSJob/Private/ConvertScriptBlockV2.ps1
@@ -1,4 +1,4 @@
-﻿Function ConvertScriptBlockV2 {
+Function ConvertScriptBlockV2 {
     Param (
         [scriptblock]$ScriptBlock,
         [bool]$HasParam,

--- a/PoshRSJob/Private/FindFunction.ps1
+++ b/PoshRSJob/Private/FindFunction.ps1
@@ -1,4 +1,4 @@
-﻿#Helper function
+#Helper function
 Function FindFunction {
     [CmdletBinding()]
     param (

--- a/PoshRSJob/Private/GetParamVariable.ps1
+++ b/PoshRSJob/Private/GetParamVariable.ps1
@@ -1,4 +1,4 @@
-﻿Function GetParamVariable {
+Function GetParamVariable {
     [CmdletBinding()]
     param (
         [scriptblock]$ScriptBlock

--- a/PoshRSJob/Private/GetUsingVariables.ps1
+++ b/PoshRSJob/Private/GetUsingVariables.ps1
@@ -1,4 +1,4 @@
-﻿Function GetUsingVariables {
+Function GetUsingVariables {
     Param ([scriptblock]$ScriptBlock)
     $ScriptBlock.ast.FindAll( {$args[0] -is [System.Management.Automation.Language.UsingExpressionAst]}, $True)
 }

--- a/PoshRSJob/Private/GetUsingVariablesV2.ps1
+++ b/PoshRSJob/Private/GetUsingVariablesV2.ps1
@@ -1,4 +1,4 @@
-﻿Function GetUsingVariablesV2 {
+Function GetUsingVariablesV2 {
     Param ([scriptblock]$ScriptBlock)
     $errors = [System.Management.Automation.PSParseError[]] @()
     $Results = [Management.Automation.PsParser]::Tokenize($ScriptBlock.tostring(), [ref] $errors)

--- a/PoshRSJob/Private/Increment.ps1
+++ b/PoshRSJob/Private/Increment.ps1
@@ -1,4 +1,4 @@
-﻿Function Increment {
+Function Increment {
     Write-Verbose "Incrementing job ID"
     Set-Variable -Name PoshRS_JobId -Value ($PoshRS_JobId + 1) -Force -Scope Global
     Write-Output $PoshRS_JobId

--- a/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
+++ b/PoshRSJob/Private/RegisterScriptScopeFunction.ps1
@@ -1,4 +1,4 @@
-﻿Function RegisterScriptScopeFunction {
+Function RegisterScriptScopeFunction {
     [cmdletbinding()]
     Param (
         [parameter()]

--- a/PoshRSJob/Private/SetIsReceived.ps1
+++ b/PoshRSJob/Private/SetIsReceived.ps1
@@ -1,4 +1,4 @@
-﻿Function SetIsReceived {
+Function SetIsReceived {
     Param (
         [parameter(ValueFromPipeline=$True)]
         [rsjob]$RSJob,

--- a/PoshRSJob/Private/WriteStream.ps1
+++ b/PoshRSJob/Private/WriteStream.ps1
@@ -1,4 +1,4 @@
-﻿Function WriteStream {
+Function WriteStream {
     [CmdletBinding()]
     Param (
         [Parameter(ValueFromPipeline=$true)]

--- a/PoshRSJob/Scripts/TabExpansion.ps1
+++ b/PoshRSJob/Scripts/TabExpansion.ps1
@@ -1,4 +1,4 @@
-﻿#region Custom Argument Completors
+#region Custom Argument Completors
 #Global variables are required for this functionality (Invoke-ScriptAnalyzer)
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidGlobalVars", "global:options")]
 param()

--- a/Tests/PoshRSJob.Tests.ps1
+++ b/Tests/PoshRSJob.Tests.ps1
@@ -289,8 +289,8 @@ Describe "Get-RSJob PS$PSVersion" {
             }
 
             $Output.Count | Should be 1
-			$Output[0] -is 'RSJob' | Should be $true
-			$Output[0].Name | Should be "TestJob $Case"
+            $Output[0] -is 'RSJob' | Should be $true
+            $Output[0].Name | Should be "TestJob $Case"
         }
     }
 }
@@ -443,7 +443,7 @@ Describe "Remove-RSJob PS$PSVersion" {
             $TestJobs.Count -gt 0 | Should Be $True
 
             $TestJob = $TestJobs | Where-Object { $_.Name -eq "TestJob $Case" }
-			$TestJob -is 'RSJob' | Should be $true
+            $TestJob -is 'RSJob' | Should be $true
 
             $AllIDs = @( $TestJobs | Select-Object -ExpandProperty Id )
 
@@ -477,15 +477,15 @@ Describe "Remove-RSJob PS$PSVersion" {
             $TestJob = 1 | Start-RSJob -Name 'ByForce' -ScriptBlock {
                 While ($True) {$Null}
             }
-			$TestJob -is 'RSJob' | Should be $true
+            $TestJob -is 'RSJob' | Should be $true
             { Remove-RSJob $TestJob -ErrorAction Stop } | Should Throw
         }
         It 'should remove job by force' {
             $TestJob = Get-RSJob -Name 'ByForce'
-			$TestJob -is 'RSJob' | Should be $true
+            $TestJob -is 'RSJob' | Should be $true
             { Remove-RSJob $TestJob -Force } | Should Not Throw
             $TestJob = Get-RSJob -Name 'ByForce'
-			$TestJob | Should BeNullOrEmpty
+            $TestJob | Should BeNullOrEmpty
         }
         It 'should remove all jobs' {
             Get-RSJob @Verbose | Remove-RSJob @Verbose

--- a/Tests/PoshRSJob.Tests.ps1
+++ b/Tests/PoshRSJob.Tests.ps1
@@ -14,8 +14,10 @@ if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master" -o
 
 Import-Module $PSScriptRoot\..\PoshRSJob\PoshRSJob -Verbose -Force -ErrorAction SilentlyContinue
 
+if (!(Test-Path Variable:PSVersion)) {
+    $PSVersion = $PSVersionTable.PSVersion.Major
+}
 <#
-$PSVersion = $PSVersionTable.PSVersion.Major
 Switch ($PSVersion) {
     4 {Import-Module $PSScriptRoot\..\PoshRSJob\PoshRSJob -Force -ErrorAction SilentlyContinue}
     2 {Import-Module PoshRSJob -Force -ErrorAction SilentlyContinue}


### PR DESCRIPTION
Changes proposed in this pull request:
 - Some files had BOM headers, these were removed so they're raw UTF8
 - Replaced the few instances of tabs with spaces
 - In the Pester tests if $PSVersion isn't defined then we define it so users can run Invoke-Pester

Has been tested on (remove any that don't apply):
 - Powershell 5.1
 - Windows 10
